### PR TITLE
🪲 BUG-#69: Fix Background mode results unreliable

### DIFF
--- a/dotflow/core/workflow.py
+++ b/dotflow/core/workflow.py
@@ -258,16 +258,26 @@ class Background(Flow):
     def _flow_callback(self, task: Task) -> None:
         self.queue.append(task)
 
+    def _run_sequential(self) -> None:
+        previous_context = Context(workflow_id=self.workflow_id)
+
+        for task in self.tasks:
+            Execution(
+                task=task,
+                workflow_id=self.workflow_id,
+                previous_context=previous_context,
+                _flow_callback=self._flow_callback,
+            )
+
+            previous_context = task.config.storage.get(
+                key=task.config.storage.key(task=task)
+            )
+
+            if not self.ignore and task.status == TypeStatus.FAILED:
+                break
+
     def run(self) -> None:
-        thread = threading.Thread(
-            target=Sequential,
-            args=(
-                self.tasks,
-                self.workflow_id,
-                self.ignore,
-                self.groups,
-            ),
-        )
+        thread = threading.Thread(target=self._run_sequential)
         thread.start()
         thread.join()
 


### PR DESCRIPTION
## Description

- `dotflow/core/workflow.py`: fixed `Background._flow_callback` to append task results to the queue (was `pass`)
- `dotflow/core/workflow.py`: fixed `Background.get_tasks()` to return `self.queue` instead of `self.tasks`
- `dotflow/core/workflow.py`: fixed `Background.run()` to execute tasks directly via `_run_sequential()` instead of delegating to `Sequential` (which used its own internal callback, bypassing Background's queue entirely)

## Motivation and Context

`Background` mode was silently delegating execution to a `Sequential` instance, which used its own `_flow_callback` and never wrote results back to `Background`'s queue. As a result, `get_tasks()` always returned the original unexecuted task list.

Closes #69

## Types of changes

- [x] Bug fix (change that fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works