### PR TITLE
docs: add docstring and return type to DotFlow.result()

### DIFF
--- a/dotflow/core/dotflow.py
+++ b/dotflow/core/dotflow.py
@@ -76,5 +76,10 @@ class DotFlow:
         """
         return [task.current_context.storage for task in self.task.queue]
 
-    def result(self):
+    def result(self) -> dict:
+        """
+        Returns:
+            dict: Returns the full workflow result serialized as a dictionary,
+                  including workflow ID and all task schemas.
+        """
         return self.task.result()


### PR DESCRIPTION
## Summary
Fixes #83

Adds the missing docstring to `DotFlow.result()` for consistency with the other `result_*` methods.

## Changes
- Added docstring to `result()` method describing its return value
- Added `-> dict` return type annotation

## Before
```python
def result(self):
    return self.task.result()
```

## After
```python
def result(self) -> dict:
    """
    Returns:
        dict: Returns the full workflow result serialized as a dictionary,
              including workflow ID and all task schemas.
    """
    return self.task.result()
```