### PR TITLE
docs: add docstring to DotFlow.result

### DIFF
--- a/dotflow/core/dotflow.py
+++ b/dotflow/core/dotflow.py
@@ -76,5 +76,10 @@ class DotFlow:
         """
         return [task.current_context.storage for task in self.task.queue]
 
-    def result(self):
+    def result(self) -> dict:
+        """
+        Returns:
+            dict: Returns the full workflow result serialized as a dictionary,
+                  including workflow ID and all task schemas.
+        """
         return self.task.result()


### PR DESCRIPTION
Add missing docstring to `DotFlow.result()` for API consistency.

Fixes #83