### PR TITLE
fix: rename _excution to _execution in execution.py

### DIFF
--- a/dotflow/core/execution.py
+++ b/dotflow/core/execution.py
@@ -54,7 +54,7 @@ class Execution:
         self.task.previous_context = previous_context
         self.task.workflow_id = workflow_id
 
-        self._excution(_flow_callback)
+        self._execution(_flow_callback)
 
     def _is_action(self, class_instance: Callable, func: Callable):
         try:
@@ -137,7 +137,7 @@ class Execution:
 
         return new_context
 
-    def _excution(self, _flow_callback):
+    def _execution(self, _flow_callback):
         try:
             start = datetime.now()
             current_context = self.task.step(


### PR DESCRIPTION
## Description

Renames the typo  to  in  in both the method definition and call site.

## Changes

- Line 57:  → 
- Line 140:  → 

## Impact

- Fixes misleading method name for contributors
- Resolves IDE/staticmethod analyzer warnings
- Makes codebase search and navigation easier

Closes #80