### PR TITLE
🪲 BUG-#127: Fix workflow_id=None passed to execution engine

### DIFF
--- a/dotflow/core/workflow.py
+++ b/dotflow/core/workflow.py
@@ -114,7 +114,7 @@ class Manager:
 
         self.tasks = execution(
             tasks=tasks,
-            workflow_id=workflow_id,
+            workflow_id=self.workflow_id,
             ignore=keep_going,
             groups=groups,
             resume=resume,


### PR DESCRIPTION
## Description

- **dotflow/core/workflow.py**: Fix `Manager.__init__` passing the raw `workflow_id` parameter (which may be `None`) to the execution engine instead of `self.workflow_id` (which holds the generated UUID)

## Motivation and Context

When no explicit `workflow_id` is provided, `Manager.__init__` generates a UUID via `uuid4()` and stores it in `self.workflow_id`. However, the execution call was passing the original parameter (`None`) instead of the resolved value. This broke checkpoint/resume and workflow identification for all auto-generated IDs.

Closes #127

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly