### PR TITLE
fix: replace self-chaining exception raise with 'from None' in retry loop

### DIFF
--- a/dotflow/core/action.py
+++ b/dotflow/core/action.py
@@ -166,7 +166,7 @@ class Action:
                     raise ExecutionWithClassError() from None
 
                 if attempt == self.retry:
-                    raise last_exception from last_exception
+                    raise last_exception from None
 
                 if task is not None:
                     task.retry_count += 1

--- a/tests/core/test_action.py
+++ b/tests/core/test_action.py
@@ -79,6 +79,21 @@ class TestClassActions(unittest.TestCase):
         self.assertEqual(len(statuses), 1)
         self.assertEqual(statuses[0], TypeStatus.RETRY)
 
+    def test_retry_exception_does_not_chain_to_itself(self):
+        def always_fail():
+            raise ValueError("fail")
+
+        inside = Action(always_fail, retry=2, retry_delay=0)
+
+        try:
+            inside()
+        except ValueError as error:
+            self.assertIsNot(
+                error.__cause__,
+                error,
+                "Exception must not be its own __cause__ (circular chain)",
+            )
+
     def test_backoff_does_not_mutate_retry_delay(self):
         def always_fail():
             raise RuntimeError("fail")


### PR DESCRIPTION
## Description

- **dotflow/core/action.py**: Replace `raise last_exception from last_exception` with `raise last_exception from None` to fix circular exception chaining
- **tests/core/test_action.py**: Add regression test asserting `__cause__` is not self-referential after retries are exhausted

## Motivation and Context

The self-chaining exception (`from last_exception`) was introduced by a ruff B904 auto-fix. It sets `__cause__` to the same object, producing confusing tracebacks. `from None` suppresses the implicit context while preserving the full original stack trace.

Closes #132

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly