### PR TITLE
fix: replace mutable default arguments in Config.__init__ with None sentinels

### DIFF
--- a/dotflow/core/config.py
+++ b/dotflow/core/config.py
@@ -61,17 +61,19 @@ class Config:
 
     def __init__(
         self,
-        storage: Storage | None = StorageDefault(),
-        notify: Notify | None = NotifyDefault(),
-        log: Log | None = LogDefault(),
-        api: Api | None = ApiDefault(),
-        scheduler: Scheduler | None = SchedulerDefault(),
+        storage: Storage | None = None,
+        notify: Notify | None = None,
+        log: Log | None = None,
+        api: Api | None = None,
+        scheduler: Scheduler | None = None,
     ) -> None:
-        self.storage = storage
-        self.notify = notify
-        self.log = log
-        self.api = api
-        self.scheduler = scheduler
+        self.storage = storage if storage is not None else StorageDefault()
+        self.notify = notify if notify is not None else NotifyDefault()
+        self.log = log if log is not None else LogDefault()
+        self.api = api if api is not None else ApiDefault()
+        self.scheduler = (
+            scheduler if scheduler is not None else SchedulerDefault()
+        )
 
         self._validate()
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -68,3 +68,18 @@ class TestConfig(unittest.TestCase):
         config = Config(scheduler=scheduler)
 
         self.assertIs(config.scheduler, scheduler)
+
+    def test_default_providers_are_not_shared_between_instances(self):
+        config_a = Config()
+        config_b = Config()
+
+        self.assertIsNot(
+            config_a.storage,
+            config_b.storage,
+            "Each Config() call must produce a fresh StorageDefault instance",
+        )
+        self.assertIsNot(
+            config_a.notify,
+            config_b.notify,
+            "Each Config() call must produce a fresh NotifyDefault instance",
+        )


### PR DESCRIPTION
Fixes #130

## Problem

Default provider instances in `Config.__init__` were defined as mutable default arguments:

```python
def __init__(
    self,
    storage: Storage | None = StorageDefault(),  # ← evaluated ONCE at class definition
    notify: Notify | None = NotifyDefault(),
    ...
```

In Python, mutable default arguments are evaluated **once** when the class is defined, not on each call. Every `Config()` instance that relies on the defaults shares the same provider objects. Mutating state on one instance's provider silently affects all others.

## Fix

Replace each default with `None` and instantiate fresh providers inside `__init__`:

```python
def __init__(self, storage=None, notify=None, ...):
    self.storage = storage if storage is not None else StorageDefault()
    self.notify = notify if notify is not None else NotifyDefault()
    ...
```

## Test

Added `test_default_providers_are_not_shared_between_instances` which asserts that two `Config()` calls produce distinct provider instances rather than the same shared object.