### PR TITLE
🪲 BUG-#133: Fix co_varnames to only include parameters, not local variables

### DIFF
--- a/dotflow/core/action.py
+++ b/dotflow/core/action.py
@@ -200,7 +200,9 @@ class Action:
     def _set_params(self):
         if isinstance(self.func, FunctionType):
             code = self.func.__code__
-            self.params = list(code.co_varnames[: code.co_argcount])
+            self.params = list(
+                code.co_varnames[: code.co_argcount + code.co_kwonlyargcount]
+            )
 
         if (
             type(self.func) is type
@@ -208,7 +210,9 @@ class Action:
             and hasattr(self.func.__init__, "__code__")
         ):
             code = self.func.__init__.__code__
-            self.params = list(code.co_varnames[: code.co_argcount])
+            self.params = list(
+                code.co_varnames[: code.co_argcount + code.co_kwonlyargcount]
+            )
 
     def _get_context(self, kwargs: dict):
         context = {}

--- a/dotflow/core/action.py
+++ b/dotflow/core/action.py
@@ -199,14 +199,16 @@ class Action:
 
     def _set_params(self):
         if isinstance(self.func, FunctionType):
-            self.params = list(self.func.__code__.co_varnames)
+            code = self.func.__code__
+            self.params = list(code.co_varnames[: code.co_argcount])
 
         if (
             type(self.func) is type
             and hasattr(self.func, "__init__")
             and hasattr(self.func.__init__, "__code__")
         ):
-            self.params = list(self.func.__init__.__code__.co_varnames)
+            code = self.func.__init__.__code__
+            self.params = list(code.co_varnames[: code.co_argcount])
 
     def _get_context(self, kwargs: dict):
         context = {}


### PR DESCRIPTION
## Description

- `dotflow/core/action.py` — Fix `_set_params` to slice `co_varnames[:co_argcount + co_kwonlyargcount]` instead of using the full `co_varnames` tuple

## Motivation and Context

`co_varnames` includes all local variables, not just parameters. A function with a local variable named `initial_context` or `previous_context` would be falsely detected as having those parameters, triggering incorrect context injection.

The fix also accounts for keyword-only parameters (`def step(*, initial_context):`) via `co_kwonlyargcount`.

Closes #133

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly