### PR TITLE
fix: use regex to match method definitions in execution orderer

### DIFF
--- a/dotflow/core/execution.py
+++ b/dotflow/core/execution.py
@@ -1,5 +1,6 @@
 """Execution module"""
 
+import re
 from collections.abc import Callable
 from datetime import datetime
 from inspect import getsourcelines
@@ -74,8 +75,9 @@ class Execution:
             inside_code = getsourcelines(class_instance.__class__)[0]
 
             for callable_name in callable_list:
+                pattern = re.compile(rf"def {re.escape(callable_name)}\s*\(")
                 for index, code in enumerate(inside_code):
-                    if code.find(f"def {callable_name}") != -1:
+                    if pattern.search(code):
                         ordered_list.append((index, callable_name))
 
             ordered_list.sort()

--- a/tests/core/test_execution.py
+++ b/tests/core/test_execution.py
@@ -13,6 +13,7 @@ from dotflow.core.types import TypeStatus
 from tests.mocks import (
     ActionStep,
     ActionStepExecutionOrderer,
+    ActionStepPrefixMethods,
     ActionStepWithContexts,
     ActionStepWithError,
     ActionStepWithInitialContext,
@@ -291,6 +292,35 @@ class TestExecution(unittest.TestCase):
             ),
             expected_value,
         )
+
+    def test_execution_orderer_prefix_methods(self):
+        """_execution_orderer must not match 'run' against a 'def run_all' line."""
+        controller = Execution(
+            task=self.task,
+            workflow_id=self.workflow_id,
+            previous_context=Context(),
+        )
+
+        class_instance = ActionStepPrefixMethods(task=controller.task).storage
+        callable_list = [
+            func
+            for func in dir(class_instance)
+            if controller._is_action(class_instance, func)
+        ]
+
+        result = controller._execution_orderer(
+            callable_list=callable_list, class_instance=class_instance
+        )
+        result_names = [name for _, name in result]
+
+        # Both methods must appear exactly once
+        self.assertEqual(result_names.count("run"), 1)
+        self.assertEqual(result_names.count("run_all"), 1)
+
+        # 'run' must appear at an earlier line than 'run_all'
+        line_run = next(idx for idx, name in result if name == "run")
+        line_run_all = next(idx for idx, name in result if name == "run_all")
+        self.assertLess(line_run, line_run_all)
 
     def test_valid_objects(self):
         valid_objects = [

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -5,6 +5,7 @@ from tests.mocks.constants import NOT_CALLABLE
 from tests.mocks.step_class import (
     ActionStep,
     ActionStepExecutionOrderer,
+    ActionStepPrefixMethods,
     ActionStepWithContexts,
     ActionStepWithError,
     ActionStepWithInitialContext,
@@ -37,6 +38,7 @@ __all__ = [
     "ActionStepWithoutInit",
     "SimpleStep",
     "ActionStepExecutionOrderer",
+    "ActionStepPrefixMethods",
     "action_step",
     "action_step_valid_object",
     "action_step_with_initial_context",

--- a/tests/mocks/step_class.py
+++ b/tests/mocks/step_class.py
@@ -89,3 +89,16 @@ class ActionStepWithoutInit:
 class SimpleStep:
     def run() -> None:
         return {"foo": "bar"}
+
+
+@action
+class ActionStepPrefixMethods:
+    """Methods where one name is a prefix of another (e.g. run vs run_all)."""
+
+    @action
+    def run() -> None:
+        return {"result": "run"}
+
+    @action
+    def run_all() -> None:
+        return {"result": "run_all"}


### PR DESCRIPTION
## Summary

Fixes #134

`_execution_orderer` in `execution.py` used `str.find(f"def {callable_name}")` to locate each method in the class source. This matches any line containing that substring, so a method named `run` would incorrectly match `def run_all(...)`, causing wrong execution order or duplicate entries.

**Root cause** (`execution.py` line 78, before fix):
```python
if code.find(f"def {callable_name}") != -1:
```

**Fix:** compile a regex that requires the name to be followed by `\s*(` — i.e., only a true `def run(...)` declaration matches:
```python
pattern = re.compile(rf"def {re.escape(callable_name)}\s*\(")
if pattern.search(code):
```

`re.escape` also guards against method names containing regex metacharacters.

## Changes

- `dotflow/core/execution.py`: import `re`; replace `str.find` with `re.compile(...).search`
- `tests/mocks/step_class.py`: add `ActionStepPrefixMethods` (methods `run` and `run_all`)
- `tests/mocks/__init__.py`: export `ActionStepPrefixMethods`
- `tests/core/test_execution.py`: add `test_execution_orderer_prefix_methods` — verifies each method appears exactly once and `run` precedes `run_all`

## Test plan

- [x] All 16 `tests/core/test_execution.py` tests pass
- [x] New test `test_execution_orderer_prefix_methods` explicitly catches the prefix-match regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)