### PR TITLE
🪲 BUG-#134: Fix method ordering to use regex matching instead of string search

### DIFF
--- a/dotflow/core/execution.py
+++ b/dotflow/core/execution.py
@@ -1,5 +1,6 @@
 """Execution module"""
 
+import re
 from collections.abc import Callable
 from datetime import datetime
 from inspect import getsourcelines
@@ -74,9 +75,13 @@ class Execution:
             inside_code = getsourcelines(class_instance.__class__)[0]
 
             for callable_name in callable_list:
+                pattern = re.compile(
+                    rf"\bdef\s+{re.escape(callable_name)}\s*\("
+                )
                 for index, code in enumerate(inside_code):
-                    if code.find(f"def {callable_name}") != -1:
+                    if pattern.search(code):
                         ordered_list.append((index, callable_name))
+                        break
 
             ordered_list.sort()
             return ordered_list

--- a/tests/core/test_execution_orderer.py
+++ b/tests/core/test_execution_orderer.py
@@ -1,0 +1,100 @@
+"""Test execution orderer with prefix method names"""
+
+import unittest
+from uuid import uuid4
+
+from dotflow.core.action import Action as action
+from dotflow.core.context import Context
+from dotflow.core.execution import Execution
+from dotflow.core.task import Task
+from tests.mocks import action_step, simple_callback
+
+
+@action
+class StepWithPrefixMethods:
+    @action
+    def run():
+        return {"method": "run"}
+
+    @action
+    def run_all():
+        return {"method": "run_all"}
+
+    @action
+    def run_all_tasks():
+        return {"method": "run_all_tasks"}
+
+
+class TestExecutionOrderer(unittest.TestCase):
+    def setUp(self):
+        self.workflow_id = uuid4()
+        self.task = Task(task_id=0, step=action_step, callback=simple_callback)
+
+    def test_prefix_methods_ordered_correctly(self):
+        controller = Execution(
+            task=self.task,
+            workflow_id=self.workflow_id,
+            previous_context=Context(),
+        )
+
+        class_instance = StepWithPrefixMethods(task=controller.task).storage
+        callable_list = [
+            func
+            for func in dir(class_instance)
+            if controller._is_action(class_instance, func)
+        ]
+
+        result = controller._execution_orderer(
+            callable_list=callable_list, class_instance=class_instance
+        )
+
+        method_names = [name for _, name in result]
+
+        self.assertEqual(len(result), 3)
+        self.assertIn("run", method_names)
+        self.assertIn("run_all", method_names)
+        self.assertIn("run_all_tasks", method_names)
+
+    def test_prefix_methods_no_duplicates(self):
+        controller = Execution(
+            task=self.task,
+            workflow_id=self.workflow_id,
+            previous_context=Context(),
+        )
+
+        class_instance = StepWithPrefixMethods(task=controller.task).storage
+        callable_list = [
+            func
+            for func in dir(class_instance)
+            if controller._is_action(class_instance, func)
+        ]
+
+        result = controller._execution_orderer(
+            callable_list=callable_list, class_instance=class_instance
+        )
+
+        method_names = [name for _, name in result]
+
+        self.assertEqual(len(method_names), len(set(method_names)))
+
+    def test_prefix_methods_source_order(self):
+        controller = Execution(
+            task=self.task,
+            workflow_id=self.workflow_id,
+            previous_context=Context(),
+        )
+
+        class_instance = StepWithPrefixMethods(task=controller.task).storage
+        callable_list = [
+            func
+            for func in dir(class_instance)
+            if controller._is_action(class_instance, func)
+        ]
+
+        result = controller._execution_orderer(
+            callable_list=callable_list, class_instance=class_instance
+        )
+
+        method_names = [name for _, name in result]
+
+        self.assertEqual(method_names, ["run", "run_all", "run_all_tasks"])


### PR DESCRIPTION
## Description

- `dotflow/core/execution.py` — Replace `code.find(f"def {callable_name}")` with `re.compile(rf"\bdef\s+{re.escape(callable_name)}\s*\(")` in `_execution_orderer`

## Motivation and Context

The previous string search could match method names that are prefixes of other methods (e.g. `run` matching `run_all`), match occurrences in comments or strings, and produce duplicate entries without a `break`.

The regex fix ensures exact method definition matching by requiring word boundary, whitespace, and opening parenthesis.

Closes #134

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly