### PR TITLE
test: add regression test for method-name prefix matching in _execution_orderer

### DIFF
--- a/tests/core/test_execution.py
+++ b/tests/core/test_execution.py
@@ -13,6 +13,7 @@ from dotflow.core.types import TypeStatus
 from tests.mocks import (
     ActionStep,
     ActionStepExecutionOrderer,
+    ActionStepPrefixMethods,
     ActionStepWithContexts,
     ActionStepWithError,
     ActionStepWithInitialContext,
@@ -291,6 +292,35 @@ class TestExecution(unittest.TestCase):
             ),
             expected_value,
         )
+
+    def test_execution_orderer_prefix_methods(self):
+        """_execution_orderer must not match 'run' against a 'def run_all' line."""
+        controller = Execution(
+            task=self.task,
+            workflow_id=self.workflow_id,
+            previous_context=Context(),
+        )
+
+        class_instance = ActionStepPrefixMethods(task=controller.task).storage
+        callable_list = [
+            func
+            for func in dir(class_instance)
+            if controller._is_action(class_instance, func)
+        ]
+
+        result = controller._execution_orderer(
+            callable_list=callable_list, class_instance=class_instance
+        )
+        result_names = [name for _, name in result]
+
+        # Both methods must appear exactly once
+        self.assertEqual(result_names.count("run"), 1)
+        self.assertEqual(result_names.count("run_all"), 1)
+
+        # 'run' must appear at an earlier line than 'run_all'
+        line_run = next(idx for idx, name in result if name == "run")
+        line_run_all = next(idx for idx, name in result if name == "run_all")
+        self.assertLess(line_run, line_run_all)
 
     def test_valid_objects(self):
         valid_objects = [

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -5,6 +5,7 @@ from tests.mocks.constants import NOT_CALLABLE
 from tests.mocks.step_class import (
     ActionStep,
     ActionStepExecutionOrderer,
+    ActionStepPrefixMethods,
     ActionStepWithContexts,
     ActionStepWithError,
     ActionStepWithInitialContext,
@@ -37,6 +38,7 @@ __all__ = [
     "ActionStepWithoutInit",
     "SimpleStep",
     "ActionStepExecutionOrderer",
+    "ActionStepPrefixMethods",
     "action_step",
     "action_step_valid_object",
     "action_step_with_initial_context",

--- a/tests/mocks/step_class.py
+++ b/tests/mocks/step_class.py
@@ -89,3 +89,16 @@ class ActionStepWithoutInit:
 class SimpleStep:
     def run() -> None:
         return {"foo": "bar"}
+
+
+@action
+class ActionStepPrefixMethods:
+    """Methods where one name is a prefix of another (e.g. run vs run_all)."""
+
+    @action
+    def run() -> None:
+        return {"result": "run"}
+
+    @action
+    def run_all() -> None:
+        return {"result": "run_all"}


### PR DESCRIPTION
## Summary

As requested in #162 — this PR adds only the test coverage for the bug fixed in #163, with no changes to production code.

## What's added

- `tests/mocks/step_class.py`: `ActionStepPrefixMethods` — a class with methods `run` and `run_all` where one name is a prefix of the other
- `tests/mocks/__init__.py`: exports `ActionStepPrefixMethods`
- `tests/core/test_execution.py`: `test_execution_orderer_prefix_methods` — asserts that `run` and `run_all` each appear exactly once in the result, and that `run` precedes `run_all`

## Note on CI

This test **intentionally fails on master** without the fix from #163 (the old `str.find()` matches `run` against `def run_all(...)`, producing a duplicate entry). It passes once #163 is merged.

Happy to rebase onto `feature/134` if that's easier to merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)