### PR TITLE
🪲 BUG-#141: Fix fork multiprocessing on macOS with OBJC safety flag

### DIFF
--- a/dotflow/core/workflow.py
+++ b/dotflow/core/workflow.py
@@ -16,7 +16,18 @@ from dotflow.core.task import Task, TaskError
 from dotflow.core.types import TypeExecution, TypeStatus
 from dotflow.utils import basic_callback
 
-_mp = get_context("fork") if sys.platform != "win32" else get_context("spawn")
+if sys.platform == "win32":
+    _mp = get_context("spawn")
+else:
+    import multiprocessing
+
+    if sys.platform == "darwin" and hasattr(
+        multiprocessing, "set_forkserver_preload"
+    ):
+        import os
+
+        os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
+    _mp = get_context("fork")
 
 
 def grouper(tasks: list[Task]) -> dict[str, list[Task]]:


### PR DESCRIPTION
## Description

- `dotflow/core/workflow.py` — Set `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` on macOS before using fork context

## Motivation and Context

On macOS, `fork()` is deprecated in the presence of threads and can cause crashes with CoreFoundation. Python 3.12+ warns about this. Using `spawn` or `forkserver` is not possible because `Action` objects are not picklable.

The `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` env var is Apple's official workaround to allow safe forking.

Closes #141

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly