### PR TITLE
🪲 BUG-#131: Fix timeout thread leak in ThreadPoolExecutor

### DIFF
--- a/dotflow/core/action.py
+++ b/dotflow/core/action.py
@@ -144,7 +144,8 @@ class Action:
         for attempt in range(1, self.retry + 1):
             try:
                 if self.timeout:
-                    with ThreadPoolExecutor(max_workers=1) as executor:
+                    executor = ThreadPoolExecutor(max_workers=1)
+                    try:
                         future = executor.submit(
                             self._call_func,
                             is_async,
@@ -152,6 +153,12 @@ class Action:
                             **kwargs,
                         )
                         result = future.result(timeout=self.timeout)
+                    except TimeoutError:
+                        future.cancel()
+                        executor.shutdown(wait=False, cancel_futures=True)
+                        raise
+                    else:
+                        executor.shutdown(wait=False)
                 else:
                     result = self._call_func(is_async, *args, **kwargs)
 

--- a/dotflow/core/action.py
+++ b/dotflow/core/action.py
@@ -164,6 +164,9 @@ class Action:
 
                 return result
 
+            except TimeoutError:
+                raise
+
             except Exception as error:
                 last_exception = error
 

--- a/dotflow/core/action.py
+++ b/dotflow/core/action.py
@@ -157,6 +157,9 @@ class Action:
                         future.cancel()
                         executor.shutdown(wait=False, cancel_futures=True)
                         raise
+                    except Exception:
+                        executor.shutdown(wait=False)
+                        raise
                     else:
                         executor.shutdown(wait=False)
                 else:


### PR DESCRIPTION
## Description

- `dotflow/core/action.py` — Replace `with ThreadPoolExecutor` context manager with explicit `shutdown(wait=False, cancel_futures=True)` on timeout

## Motivation and Context

When `future.result(timeout=...)` raises `TimeoutError`, the `with` block calls `executor.shutdown(wait=True)` which blocks until the thread finishes. If the thread is stuck, the entire workflow hangs. The fix uses `shutdown(wait=False, cancel_futures=True)` to release resources without blocking.

Closes #131

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly