### PR TITLE
🪲 BUG-#139: Add thread-safe lock to Background list append

### DIFF
--- a/dotflow/core/workflow.py
+++ b/dotflow/core/workflow.py
@@ -310,12 +310,14 @@ class Background(Flow):
 
     def setup_queue(self) -> None:
         self.queue = []
+        self._lock = threading.Lock()
 
     def get_tasks(self) -> list[Task]:
         return self.tasks
 
     def _flow_callback(self, task: Task) -> None:
-        self.queue.append(task)
+        with self._lock:
+            self.queue.append(task)
 
     def _has_checkpoint(self, task: Task) -> bool:
         if not self.resume:


### PR DESCRIPTION
## Description

- `dotflow/core/workflow.py` — Add `threading.Lock` to `Background._flow_callback` to protect `list.append` from race conditions

## Motivation and Context

`Background._flow_callback` appends to a plain list from a background thread while `get_tasks()` reads from the main thread. While CPython's GIL makes `list.append` atomic, this is an implementation detail that may not hold in other Python implementations or future versions.

Closes #139

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly