### PR TITLE
🪲 BUG-#140: Fix race condition, thread tracking, and signal handler restoration in SchedulerCron

### DIFF
--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -93,6 +93,8 @@ class SchedulerCron(Scheduler):
         self._queue_count = 0
         self._parallel_semaphore = threading.Semaphore(10)
         self._threads: list[threading.Thread] = []
+        self._prev_sigint = None
+        self._prev_sigterm = None
 
     def start(self, workflow: Callable, **kwargs) -> None:
         """Start the scheduler loop. Blocks the main thread.
@@ -131,6 +133,7 @@ class SchedulerCron(Scheduler):
             timeout: Max seconds to wait for each thread. None = wait forever.
         """
         self.running = False
+        self._restore_signals()
         for thread in self._threads:
             thread.join(timeout=timeout)
         self._threads.clear()
@@ -231,8 +234,16 @@ class SchedulerCron(Scheduler):
     def _register_signals(self) -> None:
         if threading.current_thread() is not threading.main_thread():
             return
-        signal.signal(signal.SIGINT, self._handle_signal)
-        signal.signal(signal.SIGTERM, self._handle_signal)
+        self._prev_sigint = signal.signal(signal.SIGINT, self._handle_signal)
+        self._prev_sigterm = signal.signal(signal.SIGTERM, self._handle_signal)
+
+    def _restore_signals(self) -> None:
+        if threading.current_thread() is not threading.main_thread():
+            return
+        if self._prev_sigint is not None:
+            signal.signal(signal.SIGINT, self._prev_sigint)
+        if self._prev_sigterm is not None:
+            signal.signal(signal.SIGTERM, self._prev_sigterm)
 
     def _handle_signal(self, signum, frame) -> None:
         self.stop()

--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -92,6 +92,7 @@ class SchedulerCron(Scheduler):
         self._lock = threading.Lock()
         self._queue_count = 0
         self._parallel_semaphore = threading.Semaphore(10)
+        self._threads: list[threading.Thread] = []
 
     def start(self, workflow: Callable, **kwargs) -> None:
         """Start the scheduler loop. Blocks the main thread.
@@ -123,9 +124,16 @@ class SchedulerCron(Scheduler):
 
             self._dispatch(workflow=workflow, **kwargs)
 
-    def stop(self) -> None:
-        """Stop the scheduler loop gracefully."""
+    def stop(self, timeout: float | None = None) -> None:
+        """Stop the scheduler loop and wait for in-flight threads.
+
+        Args:
+            timeout: Max seconds to wait for each thread. None = wait forever.
+        """
         self.running = False
+        for thread in self._threads:
+            thread.join(timeout=timeout)
+        self._threads.clear()
 
     def _dispatch(self, workflow: Callable, **kwargs) -> None:
         if self.overlap == TypeOverlap.SKIP:
@@ -151,6 +159,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _dispatch_queue(self, workflow: Callable, **kwargs) -> None:
@@ -166,6 +175,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _dispatch_parallel(self, workflow: Callable, **kwargs) -> None:
@@ -177,6 +187,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _execute_parallel(self, workflow: Callable, **kwargs) -> None:

--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -204,15 +204,18 @@ class SchedulerCron(Scheduler):
         finally:
             with self._lock:
                 if self._queue_count > 0:
-                    self._queue_count -= 1
-                    thread = threading.Thread(
+                    self._queue_count = 0
+                    next_thread = threading.Thread(
                         target=self._execute_queued,
                         args=(workflow,),
                         kwargs=kwargs,
                     )
-                    thread.start()
                 else:
                     self._executing = False
+                    next_thread = None
+
+            if next_thread is not None:
+                next_thread.start()
 
     def _register_signals(self) -> None:
         if threading.current_thread() is not threading.main_thread():


### PR DESCRIPTION
## Description

- `dotflow/providers/scheduler_cron.py` — Three fixes for SchedulerCron

### Fix 1 — Race condition in queue overlap (#140)
Move thread creation decision inside the lock in `_execute_queued`. The thread object is created under the lock and started after release, closing the window where `_dispatch_queue` could modify `_queue_count`.

### Fix 2 — Daemon threads never joined (#142)
Track all spawned threads in `_threads` list. `stop()` now joins all in-flight threads with an optional timeout before returning.

### Fix 3 — Signal handlers overwritten globally (#144)
Save previous SIGINT/SIGTERM handlers in `_register_signals`. Restore them in `_restore_signals` called from `stop()`.

Closes #140
Closes #142
Closes #144

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly