### PR TITLE
🪲 BUG-#140: Fix race condition in queue overlap dispatch

### DIFF
--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -204,15 +204,18 @@ class SchedulerCron(Scheduler):
         finally:
             with self._lock:
                 if self._queue_count > 0:
-                    self._queue_count -= 1
-                    thread = threading.Thread(
+                    self._queue_count = 0
+                    next_thread = threading.Thread(
                         target=self._execute_queued,
                         args=(workflow,),
                         kwargs=kwargs,
                     )
-                    thread.start()
                 else:
                     self._executing = False
+                    next_thread = None
+
+            if next_thread is not None:
+                next_thread.start()
 
     def _register_signals(self) -> None:
         if threading.current_thread() is not threading.main_thread():

--- a/tests/providers/test_scheduler_cron.py
+++ b/tests/providers/test_scheduler_cron.py
@@ -94,6 +94,28 @@ class TestSchedulerCron(unittest.TestCase):
         self.assertEqual(scheduler._queue_count, 1)
         workflow.assert_not_called()
 
+    def test_dispatch_queue_caps_at_one(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="queue")
+        scheduler._executing = True
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+        scheduler._dispatch(workflow=workflow)
+        scheduler._dispatch(workflow=workflow)
+
+        self.assertEqual(scheduler._queue_count, 1)
+
+    def test_execute_queued_resets_queue_count(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *")
+        scheduler._executing = True
+        scheduler._queue_count = 0
+        workflow = MagicMock()
+
+        scheduler._execute_queued(workflow)
+
+        self.assertFalse(scheduler._executing)
+        self.assertEqual(scheduler._queue_count, 0)
+
     def test_execute_and_reset(self):
         scheduler = SchedulerCron(cron="*/5 * * * *")
         scheduler._executing = True


### PR DESCRIPTION
## Description

- `dotflow/providers/scheduler_cron.py` — Move thread creation decision inside the lock in `_execute_queued`, closing the window where `_dispatch_queue` could modify `_queue_count`

Closes #140

## Types of changes

- [x] Bug fix (change that fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code