### PR TITLE
🪲 BUG-#142: Track and join spawned threads on scheduler stop

### DIFF
--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -92,6 +92,7 @@ class SchedulerCron(Scheduler):
         self._lock = threading.Lock()
         self._queue_count = 0
         self._parallel_semaphore = threading.Semaphore(10)
+        self._threads: list[threading.Thread] = []
 
     def start(self, workflow: Callable, **kwargs) -> None:
         """Start the scheduler loop. Blocks the main thread.
@@ -123,9 +124,16 @@ class SchedulerCron(Scheduler):
 
             self._dispatch(workflow=workflow, **kwargs)
 
-    def stop(self) -> None:
-        """Stop the scheduler loop gracefully."""
+    def stop(self, timeout: float | None = None) -> None:
+        """Stop the scheduler loop and wait for in-flight threads.
+
+        Args:
+            timeout: Max seconds to wait for each thread. None = wait forever.
+        """
         self.running = False
+        for thread in self._threads:
+            thread.join(timeout=timeout)
+        self._threads.clear()
 
     def _dispatch(self, workflow: Callable, **kwargs) -> None:
         if self.overlap == TypeOverlap.SKIP:
@@ -151,6 +159,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _dispatch_queue(self, workflow: Callable, **kwargs) -> None:
@@ -166,6 +175,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _dispatch_parallel(self, workflow: Callable, **kwargs) -> None:
@@ -177,6 +187,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _execute_parallel(self, workflow: Callable, **kwargs) -> None:

--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -131,9 +131,10 @@ class SchedulerCron(Scheduler):
             timeout: Max seconds to wait for each thread. None = wait forever.
         """
         self.running = False
-        for thread in self._threads:
+        with self._lock:
+            threads, self._threads = self._threads, []
+        for thread in threads:
             thread.join(timeout=timeout)
-        self._threads.clear()
 
     def _dispatch(self, workflow: Callable, **kwargs) -> None:
         if self.overlap == TypeOverlap.SKIP:
@@ -148,6 +149,11 @@ class SchedulerCron(Scheduler):
                 self.overlap,
             )
 
+    def _track_thread(self, thread: threading.Thread) -> None:
+        with self._lock:
+            self._threads = [t for t in self._threads if t.is_alive()]
+            self._threads.append(thread)
+
     def _dispatch_skip(self, workflow: Callable, **kwargs) -> None:
         with self._lock:
             if self._executing:
@@ -159,7 +165,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
-        self._threads.append(thread)
+        self._track_thread(thread)
         thread.start()
 
     def _dispatch_queue(self, workflow: Callable, **kwargs) -> None:
@@ -175,7 +181,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
-        self._threads.append(thread)
+        self._track_thread(thread)
         thread.start()
 
     def _dispatch_parallel(self, workflow: Callable, **kwargs) -> None:
@@ -187,7 +193,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
-        self._threads.append(thread)
+        self._track_thread(thread)
         thread.start()
 
     def _execute_parallel(self, workflow: Callable, **kwargs) -> None:
@@ -226,6 +232,7 @@ class SchedulerCron(Scheduler):
                     next_thread = None
 
             if next_thread is not None:
+                self._track_thread(next_thread)
                 next_thread.start()
 
     def _register_signals(self) -> None:

--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -204,15 +204,18 @@ class SchedulerCron(Scheduler):
         finally:
             with self._lock:
                 if self._queue_count > 0:
-                    self._queue_count -= 1
-                    thread = threading.Thread(
+                    self._queue_count = 0
+                    next_thread = threading.Thread(
                         target=self._execute_queued,
                         args=(workflow,),
                         kwargs=kwargs,
                     )
-                    thread.start()
                 else:
                     self._executing = False
+                    next_thread = None
+
+            if next_thread is not None:
+                next_thread.start()
 
     def _register_signals(self) -> None:
         if threading.current_thread() is not threading.main_thread():

--- a/tests/providers/test_scheduler_cron.py
+++ b/tests/providers/test_scheduler_cron.py
@@ -104,6 +104,72 @@ class TestSchedulerCron(unittest.TestCase):
         workflow.assert_called_once()
         self.assertFalse(scheduler._executing)
 
+    def test_dispatch_queue_caps_at_one(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="queue")
+        scheduler._executing = True
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+        scheduler._dispatch(workflow=workflow)
+        scheduler._dispatch(workflow=workflow)
+
+        self.assertEqual(scheduler._queue_count, 1)
+
+    def test_execute_queued_resets_queue_count(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *")
+        scheduler._executing = True
+        scheduler._queue_count = 0
+        workflow = MagicMock()
+
+        scheduler._execute_queued(workflow)
+
+        self.assertFalse(scheduler._executing)
+        self.assertEqual(scheduler._queue_count, 0)
+
+    def test_thread_tracking_on_dispatch(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="skip")
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                t.join(timeout=2)
+
+        self.assertGreaterEqual(len(scheduler._threads), 1)
+
+    def test_stop_clears_threads(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="skip")
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                t.join(timeout=2)
+
+        scheduler.stop(timeout=2)
+
+        self.assertEqual(scheduler._threads, [])
+
+    def test_dead_threads_pruned(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="skip")
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                t.join(timeout=2)
+
+        scheduler._executing = False
+        scheduler._dispatch(workflow=workflow)
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                t.join(timeout=2)
+
+        alive = [t for t in scheduler._threads if t.is_alive()]
+        self.assertEqual(len(alive), 0)
+
     def test_handle_signal(self):
         scheduler = SchedulerCron(cron="*/5 * * * *")
         scheduler.running = True


### PR DESCRIPTION
## Description

- `dotflow/providers/scheduler_cron.py` — Track all spawned threads in `_threads` list. `stop()` now joins in-flight threads with an optional timeout before returning.

Closes #142

## Types of changes

- [x] Bug fix (change that fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code