### PR TITLE
🪲 BUG-#144: Save and restore signal handlers on scheduler start/stop

### DIFF
--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -134,9 +134,10 @@ class SchedulerCron(Scheduler):
         """
         self.running = False
         self._restore_signals()
-        for thread in self._threads:
+        with self._lock:
+            threads, self._threads = self._threads, []
+        for thread in threads:
             thread.join(timeout=timeout)
-        self._threads.clear()
 
     def _dispatch(self, workflow: Callable, **kwargs) -> None:
         if self.overlap == TypeOverlap.SKIP:
@@ -151,6 +152,11 @@ class SchedulerCron(Scheduler):
                 self.overlap,
             )
 
+    def _track_thread(self, thread: threading.Thread) -> None:
+        with self._lock:
+            self._threads = [t for t in self._threads if t.is_alive()]
+            self._threads.append(thread)
+
     def _dispatch_skip(self, workflow: Callable, **kwargs) -> None:
         with self._lock:
             if self._executing:
@@ -162,7 +168,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
-        self._threads.append(thread)
+        self._track_thread(thread)
         thread.start()
 
     def _dispatch_queue(self, workflow: Callable, **kwargs) -> None:
@@ -178,7 +184,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
-        self._threads.append(thread)
+        self._track_thread(thread)
         thread.start()
 
     def _dispatch_parallel(self, workflow: Callable, **kwargs) -> None:
@@ -190,7 +196,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
-        self._threads.append(thread)
+        self._track_thread(thread)
         thread.start()
 
     def _execute_parallel(self, workflow: Callable, **kwargs) -> None:
@@ -229,6 +235,7 @@ class SchedulerCron(Scheduler):
                     next_thread = None
 
             if next_thread is not None:
+                self._track_thread(next_thread)
                 next_thread.start()
 
     def _register_signals(self) -> None:
@@ -242,8 +249,10 @@ class SchedulerCron(Scheduler):
             return
         if self._prev_sigint is not None:
             signal.signal(signal.SIGINT, self._prev_sigint)
+            self._prev_sigint = None
         if self._prev_sigterm is not None:
             signal.signal(signal.SIGTERM, self._prev_sigterm)
+            self._prev_sigterm = None
 
     def _handle_signal(self, signum, frame) -> None:
         self.stop()

--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -93,6 +93,8 @@ class SchedulerCron(Scheduler):
         self._queue_count = 0
         self._parallel_semaphore = threading.Semaphore(10)
         self._threads: list[threading.Thread] = []
+        self._prev_sigint = None
+        self._prev_sigterm = None
 
     def start(self, workflow: Callable, **kwargs) -> None:
         """Start the scheduler loop. Blocks the main thread.
@@ -131,6 +133,7 @@ class SchedulerCron(Scheduler):
             timeout: Max seconds to wait for each thread. None = wait forever.
         """
         self.running = False
+        self._restore_signals()
         for thread in self._threads:
             thread.join(timeout=timeout)
         self._threads.clear()
@@ -231,8 +234,16 @@ class SchedulerCron(Scheduler):
     def _register_signals(self) -> None:
         if threading.current_thread() is not threading.main_thread():
             return
-        signal.signal(signal.SIGINT, self._handle_signal)
-        signal.signal(signal.SIGTERM, self._handle_signal)
+        self._prev_sigint = signal.signal(signal.SIGINT, self._handle_signal)
+        self._prev_sigterm = signal.signal(signal.SIGTERM, self._handle_signal)
+
+    def _restore_signals(self) -> None:
+        if threading.current_thread() is not threading.main_thread():
+            return
+        if self._prev_sigint is not None:
+            signal.signal(signal.SIGINT, self._prev_sigint)
+        if self._prev_sigterm is not None:
+            signal.signal(signal.SIGTERM, self._prev_sigterm)
 
     def _handle_signal(self, signum, frame) -> None:
         self.stop()

--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -92,6 +92,7 @@ class SchedulerCron(Scheduler):
         self._lock = threading.Lock()
         self._queue_count = 0
         self._parallel_semaphore = threading.Semaphore(10)
+        self._threads: list[threading.Thread] = []
 
     def start(self, workflow: Callable, **kwargs) -> None:
         """Start the scheduler loop. Blocks the main thread.
@@ -123,9 +124,16 @@ class SchedulerCron(Scheduler):
 
             self._dispatch(workflow=workflow, **kwargs)
 
-    def stop(self) -> None:
-        """Stop the scheduler loop gracefully."""
+    def stop(self, timeout: float | None = None) -> None:
+        """Stop the scheduler loop and wait for in-flight threads.
+
+        Args:
+            timeout: Max seconds to wait for each thread. None = wait forever.
+        """
         self.running = False
+        for thread in self._threads:
+            thread.join(timeout=timeout)
+        self._threads.clear()
 
     def _dispatch(self, workflow: Callable, **kwargs) -> None:
         if self.overlap == TypeOverlap.SKIP:
@@ -151,6 +159,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _dispatch_queue(self, workflow: Callable, **kwargs) -> None:
@@ -166,6 +175,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _dispatch_parallel(self, workflow: Callable, **kwargs) -> None:
@@ -177,6 +187,7 @@ class SchedulerCron(Scheduler):
             args=(workflow,),
             kwargs=kwargs,
         )
+        self._threads.append(thread)
         thread.start()
 
     def _execute_parallel(self, workflow: Callable, **kwargs) -> None:

--- a/dotflow/providers/scheduler_cron.py
+++ b/dotflow/providers/scheduler_cron.py
@@ -204,15 +204,18 @@ class SchedulerCron(Scheduler):
         finally:
             with self._lock:
                 if self._queue_count > 0:
-                    self._queue_count -= 1
-                    thread = threading.Thread(
+                    self._queue_count = 0
+                    next_thread = threading.Thread(
                         target=self._execute_queued,
                         args=(workflow,),
                         kwargs=kwargs,
                     )
-                    thread.start()
                 else:
                     self._executing = False
+                    next_thread = None
+
+            if next_thread is not None:
+                next_thread.start()
 
     def _register_signals(self) -> None:
         if threading.current_thread() is not threading.main_thread():

--- a/tests/providers/test_scheduler_cron.py
+++ b/tests/providers/test_scheduler_cron.py
@@ -41,6 +41,9 @@ class TestSchedulerCron(unittest.TestCase):
         self.assertFalse(scheduler.running)
         self.assertFalse(scheduler._executing)
         self.assertEqual(scheduler._queue_count, 0)
+        self.assertEqual(scheduler._threads, [])
+        self.assertIsNone(scheduler._prev_sigint)
+        self.assertIsNone(scheduler._prev_sigterm)
 
     def test_stop(self):
         scheduler = SchedulerCron(cron="*/5 * * * *")
@@ -94,6 +97,17 @@ class TestSchedulerCron(unittest.TestCase):
         self.assertEqual(scheduler._queue_count, 1)
         workflow.assert_not_called()
 
+    def test_dispatch_queue_caps_at_one(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="queue")
+        scheduler._executing = True
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+        scheduler._dispatch(workflow=workflow)
+        scheduler._dispatch(workflow=workflow)
+
+        self.assertEqual(scheduler._queue_count, 1)
+
     def test_execute_and_reset(self):
         scheduler = SchedulerCron(cron="*/5 * * * *")
         scheduler._executing = True
@@ -104,6 +118,17 @@ class TestSchedulerCron(unittest.TestCase):
         workflow.assert_called_once()
         self.assertFalse(scheduler._executing)
 
+    def test_execute_queued_resets_queue_count(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *")
+        scheduler._executing = True
+        scheduler._queue_count = 0
+        workflow = MagicMock()
+
+        scheduler._execute_queued(workflow)
+
+        self.assertFalse(scheduler._executing)
+        self.assertEqual(scheduler._queue_count, 0)
+
     def test_handle_signal(self):
         scheduler = SchedulerCron(cron="*/5 * * * *")
         scheduler.running = True
@@ -111,6 +136,72 @@ class TestSchedulerCron(unittest.TestCase):
         scheduler._handle_signal(signum=2, frame=None)
 
         self.assertFalse(scheduler.running)
+
+    def test_thread_tracking_on_dispatch(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="skip")
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                t.join(timeout=2)
+
+        self.assertGreaterEqual(len(scheduler._threads), 1)
+
+    def test_stop_clears_threads(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="skip")
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                t.join(timeout=2)
+
+        scheduler.stop(timeout=2)
+
+        self.assertEqual(scheduler._threads, [])
+
+    def test_dead_threads_pruned(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *", overlap="skip")
+        workflow = MagicMock()
+
+        scheduler._dispatch(workflow=workflow)
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                t.join(timeout=2)
+
+        scheduler._executing = False
+        scheduler._dispatch(workflow=workflow)
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                t.join(timeout=2)
+
+        alive = [t for t in scheduler._threads if t.is_alive()]
+        self.assertEqual(len(alive), 0)
+
+    def test_signal_handlers_restored_on_stop(self):
+        import signal
+
+        scheduler = SchedulerCron(cron="*/5 * * * *")
+        original_sigint = signal.getsignal(signal.SIGINT)
+
+        scheduler._register_signals()
+        self.assertNotEqual(signal.getsignal(signal.SIGINT), original_sigint)
+
+        scheduler._restore_signals()
+        self.assertEqual(signal.getsignal(signal.SIGINT), original_sigint)
+
+    def test_double_restore_is_safe(self):
+        scheduler = SchedulerCron(cron="*/5 * * * *")
+
+        scheduler._register_signals()
+        scheduler._restore_signals()
+        scheduler._restore_signals()
+
+        self.assertIsNone(scheduler._prev_sigint)
+        self.assertIsNone(scheduler._prev_sigterm)
 
     def test_run_stops_gracefully(self):
         from datetime import datetime, timedelta


### PR DESCRIPTION
## Description

- `dotflow/providers/scheduler_cron.py` — Save previous SIGINT/SIGTERM handlers in `_register_signals` and restore them in `stop()` via `_restore_signals`

Closes #144

## Types of changes

- [x] Bug fix (change that fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code