### PR TITLE
⚙️ FEATURE-#184: Add NotifyDiscord provider and rename Notify.send to hook_status_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Extend Dotflow by implementing the abstract base classes:
 | ABC | Methods | Purpose |
 |-----|---------|---------|
 | `Storage` | `post`, `get`, `key` | Custom storage backends |
-| `Notify` | `send` | Custom notification channels |
+| `Notify` | `hook_status_task` | Custom notification channels |
 | `Log` | `info`, `error` | Custom logging |
 | `Scheduler` | `start`, `stop` | Custom scheduling strategies |
 

--- a/docs/nav/advanced/notifications-on-failure.md
+++ b/docs/nav/advanced/notifications-on-failure.md
@@ -9,7 +9,7 @@ Configure your workflow to send notifications only when tasks fail. Useful for m
 ## How it works
 
 1. `NotifyTelegram` is configured with `notification_type=TypeStatus.FAILED`
-2. After each task completes, dotflow calls `notify.send(task)`
+2. After each task status changes, dotflow calls `notify.hook_status_task(task)`
 3. The provider checks if `task.status` matches the configured `notification_type`
 4. Only failed tasks trigger a Telegram message
 
@@ -24,5 +24,6 @@ Configure your workflow to send notifications only when tasks fail. Useful for m
 ## References
 
 - [NotifyTelegram](https://dotflow-io.github.io/dotflow/nav/reference/notify-telegram/)
+- [NotifyDiscord](https://dotflow-io.github.io/dotflow/nav/reference/notify-discord/)
 - [Notify Provider](https://dotflow-io.github.io/dotflow/nav/tutorial/notify-default/)
 - [Error Handling](https://dotflow-io.github.io/dotflow/nav/tutorial/error-handling/)

--- a/docs/nav/development/custom-providers.md
+++ b/docs/nav/development/custom-providers.md
@@ -11,7 +11,7 @@ This means you can persist task output to any database, send notifications to an
 | ABC | Import | Methods | Purpose |
 |-----|--------|---------|---------|
 | `Storage` | `dotflow.abc.storage` | `post()`, `get()`, `key()` | Persist and retrieve task context between steps |
-| `Notify` | `dotflow.abc.notify` | `send()` | Send notifications when tasks complete or fail |
+| `Notify` | `dotflow.abc.notify` | `hook_status_task()` | Hook called when a task status changes |
 | `Log` | `dotflow.abc.log` | `info()`, `error()` | Log task status changes during execution |
 | `Scheduler` | `dotflow.abc.scheduler` | `start()`, `stop()` | Control recurring workflow execution on a schedule |
 
@@ -79,9 +79,9 @@ class SchedulerInterval(Scheduler):
 
 ## Custom Notify
 
-The `Notify` provider is called after each task finishes. It receives the full task object, so you can inspect its status, errors, context, and duration to decide what to send and where.
+The `Notify` provider is called when a task status changes. It receives the full task object, so you can inspect its status, errors, context, and duration to decide what to send and where.
 
-- `send(task)` — send a notification based on the task state
+- `hook_status_task(task)` — hook called when a task status changes
 
 ```python
 from typing import Any
@@ -93,7 +93,7 @@ class NotifySlack(Notify):
     def __init__(self, webhook_url: str):
         self.webhook_url = webhook_url
 
-    def send(self, task: Any) -> None:
+    def hook_status_task(self, task: Any) -> None:
         import requests
         requests.post(self.webhook_url, json={
             "text": f"Task {task.task_id}: {task.status}"

--- a/docs/nav/integrations/index.md
+++ b/docs/nav/integrations/index.md
@@ -42,6 +42,20 @@
 
 </div>
 
+## Discord
+
+<div class="grid cards dotflow-integration-grid" markdown>
+
+- :fontawesome-brands-discord: __Discord Webhook__
+
+    ---
+
+    Send workflow updates through **Discord** channels.
+
+    [:octicons-arrow-right-24: How-to](../tutorial/notify-discord.md)
+
+</div>
+
 ## Built-in
 
 <div class="grid cards dotflow-integration-grid" markdown>

--- a/docs/nav/integrations/use-integrations.md
+++ b/docs/nav/integrations/use-integrations.md
@@ -22,7 +22,7 @@ pip install "dotflow[gcp,scheduler]"
 The authoritative list of extras and pinned versions lives in [`pyproject.toml`](https://github.com/dotflow-io/dotflow/blob/main/pyproject.toml) under `[project.optional-dependencies]`.
 
 /// note
-Built-in providers (default storage, file storage, default notify/log/scheduler) use only **core** dependencies—no extra needed. [Telegram](../tutorial/notify-telegram.md) uses `requests`, which is already a dependency of `dotflow`.
+Built-in providers (default storage, file storage, default notify/log/scheduler) use only **core** dependencies—no extra needed. [Telegram](../tutorial/notify-telegram.md) and [Discord](../tutorial/notify-discord.md) use `requests`, which is already a dependency of `dotflow`.
 ///
 
 ## Use a provider in code
@@ -55,7 +55,7 @@ workflow.task.add(step=step_one)
 workflow.start()
 ```
 
-The same pattern applies to **GCS** (`StorageGCS`), **cron** (`SchedulerCron` on `Config.scheduler`), **Telegram** (`NotifyTelegram` on `Config.notify`), and other providers—each [integration guide](index.md) shows the exact constructor arguments and auth model.
+The same pattern applies to **GCS** (`StorageGCS`), **cron** (`SchedulerCron` on `Config.scheduler`), **Telegram** (`NotifyTelegram` on `Config.notify`), **Discord** (`NotifyDiscord` on `Config.notify`), and other providers—each [integration guide](index.md) shows the exact constructor arguments and auth model.
 
 ## If import fails
 

--- a/docs/nav/reference/notify-discord.md
+++ b/docs/nav/reference/notify-discord.md
@@ -1,0 +1,3 @@
+# NotifyDiscord
+
+::: dotflow.providers.notify_discord.NotifyDiscord

--- a/docs/nav/tutorial/notify-discord.md
+++ b/docs/nav/tutorial/notify-discord.md
@@ -1,0 +1,49 @@
+# Notify Discord
+
+`NotifyDiscord` sends task notifications to a Discord channel via webhook. You can filter notifications by task status — for example, only receive alerts when a task fails.
+
+## Setup
+
+### 1. Create a webhook
+
+1. Open your Discord server
+2. Go to channel settings → **Integrations** → **Webhooks**
+3. Click **New Webhook** and copy the URL
+
+/// tip
+Store your webhook URL in an environment variable or a `.env` file. Never hardcode secrets in your source code.
+///
+
+## Example
+
+{* ./docs_src/notify/notify_discord.py hl[7,23:27,29] *}
+
+## Notification types
+
+| `notification_type` | When notified |
+|---------------------|---------------|
+| `TypeStatus.FAILED` | Only on failure |
+| `TypeStatus.COMPLETED` | Only on success |
+| `None` (default) | Every task, regardless of status |
+
+## Show result
+
+Set `show_result=True` to include the task result (as JSON) in the notification embed. Disabled by default to keep messages compact — enable it when you need to inspect output without checking logs.
+
+| `show_result` | Behavior |
+|---------------|----------|
+| `False` (default) | Only status, workflow ID, and task ID |
+| `True` | Adds a `Result` field with the task output as JSON |
+
+## Message format
+
+Notifications are sent as Discord embeds with:
+
+- Task status with emoji indicator
+- Workflow ID and Task ID
+- Task result as JSON (when `show_result=True`)
+- Error details (when failed)
+
+## References
+
+- [NotifyDiscord](https://dotflow-io.github.io/dotflow/nav/reference/notify-discord/)

--- a/docs/nav/tutorial/notify-telegram.md
+++ b/docs/nav/tutorial/notify-telegram.md
@@ -32,7 +32,7 @@ Store your token and chat ID in environment variables or a `.env` file. Never ha
 
 ## Example
 
-{* ./docs_src/notify/notify_telegram.py hl[8,26:30,32] *}
+{* ./docs_src/notify/notify_telegram.py hl[7,23:28,30] *}
 
 ## Notification types
 
@@ -41,6 +41,24 @@ Store your token and chat ID in environment variables or a `.env` file. Never ha
 | `TypeStatus.FAILED` | Only on failure |
 | `TypeStatus.COMPLETED` | Only on success |
 | `None` (default) | Every task, regardless of status |
+
+## Show result
+
+Set `show_result=True` to include the task result (as JSON) in the notification message. Disabled by default to keep messages compact.
+
+| `show_result` | Behavior |
+|---------------|----------|
+| `False` (default) | Only status, workflow ID, and task ID |
+| `True` | Adds the task output as a JSON code block |
+
+## Message format
+
+Notifications are sent as Telegram messages with:
+
+- Task status with emoji indicator
+- Workflow ID and Task ID
+- Task result as JSON (when `show_result=True`)
+- Error details (when failed)
 
 ## References
 

--- a/docs_src/notify/notify_discord.py
+++ b/docs_src/notify/notify_discord.py
@@ -1,0 +1,38 @@
+import os
+
+from dotenv import load_dotenv
+
+from dotflow import Config, DotFlow, action
+from dotflow.core.types.status import TypeStatus
+from dotflow.providers import NotifyDiscord
+
+
+@action
+def step_one():
+    return {"data": "processed"}
+
+
+@action
+def step_two():
+    raise RuntimeError("Fail!")
+
+
+def main():
+    load_dotenv()
+
+    notify = NotifyDiscord(
+        webhook_url=os.getenv("DISCORD_WEBHOOK_URL", ""),
+        notification_type=TypeStatus.FAILED,
+        show_result=True,
+    )
+
+    workflow = DotFlow(config=Config(notify=notify))
+    workflow.task.add(step=step_one)
+    workflow.task.add(step=step_two)
+    workflow.start()
+
+    return workflow
+
+
+if __name__ == "__main__":
+    main()

--- a/docs_src/notify/notify_telegram.py
+++ b/docs_src/notify/notify_telegram.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 from dotenv import load_dotenv
 
@@ -9,14 +8,12 @@ from dotflow.providers import NotifyTelegram
 
 
 @action
-def simple_step(initial_context):
-    time.sleep(0.5)
-
-    return initial_context.storage
+def step_one():
+    return {"data": "processed"}
 
 
 @action
-def simple_step_raise():
+def step_two():
     raise RuntimeError("Fail!")
 
 
@@ -27,11 +24,12 @@ def main():
         token=os.getenv("BOT_TOKEN", ""),
         chat_id=int(os.getenv("CHAT_ID", "0")),
         notification_type=TypeStatus.FAILED,
+        show_result=True,
     )
 
     workflow = DotFlow(config=Config(notify=notify))
-    workflow.task.add(step=simple_step, initial_context={"foo": "bar"})
-    workflow.task.add(step=simple_step_raise)
+    workflow.task.add(step=step_one)
+    workflow.task.add(step=step_two)
     workflow.start()
 
     return workflow

--- a/dotflow/abc/notify.py
+++ b/dotflow/abc/notify.py
@@ -8,5 +8,5 @@ class Notify(ABC):
     """Notify"""
 
     @abstractmethod
-    def send(self, task: Any) -> None:
-        """Send"""
+    def hook_status_task(self, task: Any) -> None:
+        """Hook called when a task status changes."""

--- a/dotflow/core/task.py
+++ b/dotflow/core/task.py
@@ -248,7 +248,7 @@ class Task(TaskInstance):
     def status(self, value: TypeStatus) -> None:
         self._status = value
 
-        self.config.notify.send(task=self)
+        self.config.notify.hook_status_task(task=self)
         self.config.log.info(task=self)
 
     @property

--- a/dotflow/providers/__init__.py
+++ b/dotflow/providers/__init__.py
@@ -2,6 +2,7 @@
 
 from dotflow.providers.log_default import LogDefault
 from dotflow.providers.notify_default import NotifyDefault
+from dotflow.providers.notify_discord import NotifyDiscord
 from dotflow.providers.notify_telegram import NotifyTelegram
 from dotflow.providers.scheduler_default import SchedulerDefault
 from dotflow.providers.storage_default import StorageDefault
@@ -10,6 +11,7 @@ from dotflow.providers.storage_file import StorageFile
 __all__ = [
     "LogDefault",
     "NotifyDefault",
+    "NotifyDiscord",
     "NotifyTelegram",
     "SchedulerCron",
     "SchedulerDefault",

--- a/dotflow/providers/notify_default.py
+++ b/dotflow/providers/notify_default.py
@@ -6,5 +6,5 @@ from dotflow.abc.notify import Notify
 
 
 class NotifyDefault(Notify):
-    def send(self, task: Any) -> None:
+    def hook_status_task(self, task: Any) -> None:
         pass

--- a/dotflow/providers/notify_discord.py
+++ b/dotflow/providers/notify_discord.py
@@ -103,18 +103,10 @@ class NotifyDiscord(Notify):
             )
 
         if task.status == TypeStatus.FAILED and task.errors:
-            last_error = (
-                task.errors[-1]
-                if isinstance(task.errors, list)
-                else task.errors
-            )
+            last_error = task.errors[-1]
+            error_value = f"`{last_error.exception}`: {last_error.message}"
             embed["fields"].append(
-                {
-                    "name": "Error",
-                    "value": f"`{last_error.exception}`: {last_error.message}"[
-                        :1024
-                    ],
-                }
+                {"name": "Error", "value": error_value[:1024]}
             )
 
         return embed

--- a/dotflow/providers/notify_discord.py
+++ b/dotflow/providers/notify_discord.py
@@ -1,0 +1,120 @@
+"""Notify Discord"""
+
+from __future__ import annotations
+
+from json import dumps
+from typing import Any
+
+from requests import post
+
+from dotflow.abc.notify import Notify
+from dotflow.core.types.status import TypeStatus
+from dotflow.logging import logger
+
+
+class NotifyDiscord(Notify):
+    """
+    Import:
+        You can import the **NotifyDiscord** class with:
+
+            from dotflow.providers import NotifyDiscord
+
+    Example:
+        `class` dotflow.providers.notify_discord.NotifyDiscord
+
+            from dotflow import Config, DotFlow
+            from dotflow.providers import NotifyDiscord
+            from dotflow.core.types.status import TypeStatus
+
+            config = Config(
+                notify=NotifyDiscord(
+                    webhook_url="https://discord.com/api/webhooks/...",
+                    notification_type=TypeStatus.FAILED,
+                )
+            )
+
+            workflow = DotFlow(config=config)
+
+    Args:
+        webhook_url (str): Discord webhook URL.
+
+        notification_type (Optional[TypeStatus]): Filter notifications
+            by task status. If None, all statuses are notified.
+
+        show_result (bool): Include task result in the notification.
+            Defaults to False.
+
+        timeout (float): Request timeout in seconds.
+    """
+
+    COLORS = {
+        TypeStatus.COMPLETED: 0x4CAF50,
+        TypeStatus.FAILED: 0xF44336,
+        TypeStatus.RETRY: 0xFF9800,
+        TypeStatus.IN_PROGRESS: 0x2196F3,
+        TypeStatus.NOT_STARTED: 0x9E9E9E,
+        TypeStatus.PAUSED: 0x607D8B,
+    }
+
+    def __init__(
+        self,
+        webhook_url: str,
+        notification_type: TypeStatus | None = None,
+        show_result: bool = False,
+        timeout: float = 1.5,
+    ):
+        self.webhook_url = webhook_url
+        self.notification_type = notification_type
+        self.show_result = show_result
+        self.timeout = timeout
+
+    def hook_status_task(self, task: Any) -> None:
+        if self.notification_type and self.notification_type != task.status:
+            return
+
+        try:
+            response = post(
+                url=self.webhook_url,
+                headers={"Content-Type": "application/json"},
+                data=dumps({"embeds": [self._build_embed(task)]}),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except Exception as error:
+            logger.error(
+                "Internal problem sending notification on Discord: %s",
+                str(error),
+            )
+
+    def _build_embed(self, task: Any) -> dict:
+        embed = {
+            "title": f"{TypeStatus.get_symbol(task.status)} {task.status}",
+            "color": self.COLORS.get(task.status, 0x9E9E9E),
+            "description": f"`{task.workflow_id}` — Task {task.task_id}",
+            "fields": [],
+        }
+
+        if self.show_result:
+            embed["fields"].append(
+                {
+                    "name": "Result",
+                    "value": f"```json\n{task.result(max=1024)}```",
+                }
+            )
+
+        if task.status == TypeStatus.FAILED and task.errors:
+            last_error = (
+                task.errors[-1]
+                if isinstance(task.errors, list)
+                else task.errors
+            )
+            embed["fields"].append(
+                {
+                    "name": "Error",
+                    "value": f"`{last_error.exception}`: {last_error.message}"[
+                        :1024
+                    ],
+                }
+            )
+
+        return embed

--- a/dotflow/providers/notify_telegram.py
+++ b/dotflow/providers/notify_telegram.py
@@ -1,4 +1,4 @@
-"""Notify Default"""
+"""Notify Telegram"""
 
 from __future__ import annotations
 
@@ -13,47 +13,101 @@ from dotflow.logging import logger
 
 
 class NotifyTelegram(Notify):
-    MESSAGE = "{symbol} {status}\n```json\n{task}```\n{workflow_id}-{task_id}"
-    API_TELEGRAM = "https://api.telegram.org/bot{token}/sendMessage"
+    """
+    Import:
+        You can import the **NotifyTelegram** class with:
+
+            from dotflow.providers import NotifyTelegram
+
+    Example:
+        `class` dotflow.providers.notify_telegram.NotifyTelegram
+
+            from dotflow import Config, DotFlow
+            from dotflow.providers import NotifyTelegram
+            from dotflow.core.types.status import TypeStatus
+
+            config = Config(
+                notify=NotifyTelegram(
+                    token="YOUR_BOT_TOKEN",
+                    chat_id=123456789,
+                    notification_type=TypeStatus.FAILED,
+                )
+            )
+
+            workflow = DotFlow(config=config)
+
+    Args:
+        token (str): Telegram bot token from BotFather.
+
+        chat_id (int): Telegram chat ID to send messages to.
+
+        notification_type (Optional[TypeStatus]): Filter notifications
+            by task status. If None, all statuses are notified.
+
+        show_result (bool): Include task result in the notification.
+            Defaults to False.
+
+        timeout (float): Request timeout in seconds.
+    """
+
+    API_URL = "https://api.telegram.org/bot{token}/sendMessage"
 
     def __init__(
         self,
         token: str,
         chat_id: int,
         notification_type: TypeStatus | None = None,
-        timeout: int = 1.5,
+        show_result: bool = False,
+        timeout: float = 1.5,
     ):
         self.token = token
         self.chat_id = chat_id
         self.notification_type = notification_type
+        self.show_result = show_result
         self.timeout = timeout
 
-    def send(self, task: Any) -> None:
-        if not self.notification_type or self.notification_type == task.status:
-            data = {
-                "chat_id": self.chat_id,
-                "text": self._get_text(task=task),
-                "parse_mode": "markdown",
-            }
-            try:
-                response = post(
-                    url=self.API_TELEGRAM.format(token=self.token),
-                    headers={"Content-Type": "application/json"},
-                    data=dumps(data),
-                    timeout=self.timeout,
-                )
-                response.raise_for_status()
-            except Exception as error:
-                logger.error(
-                    "Internal problem sending notification on Telegram: %s",
-                    str(error),
-                )
+    def hook_status_task(self, task: Any) -> None:
+        if self.notification_type and self.notification_type != task.status:
+            return
 
-    def _get_text(self, task: Any) -> str:
-        return self.MESSAGE.format(
-            symbol=TypeStatus.get_symbol(task.status),
-            status=task.status,
-            workflow_id=task.workflow_id,
-            task_id=task.task_id,
-            task=task.result(max=4000),
-        )
+        try:
+            response = post(
+                url=self.API_URL.format(token=self.token),
+                headers={"Content-Type": "application/json"},
+                data=dumps(
+                    {
+                        "chat_id": self.chat_id,
+                        "text": self._build_message(task),
+                        "parse_mode": "markdown",
+                    }
+                ),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except Exception as error:
+            logger.error(
+                "Internal problem sending notification on Telegram: %s",
+                str(error),
+            )
+
+    def _build_message(self, task: Any) -> str:
+        symbol = TypeStatus.get_symbol(task.status)
+        header = f"{symbol} {task.status}"
+        footer = f"`{task.workflow_id}` — Task {task.task_id}"
+
+        parts = [header]
+
+        if self.show_result:
+            parts.append(f"```json\n{task.result(max=4000)}```")
+
+        if task.status == TypeStatus.FAILED and task.errors:
+            last_error = (
+                task.errors[-1]
+                if isinstance(task.errors, list)
+                else task.errors
+            )
+            parts.append(f"`{last_error.exception}`: {last_error.message}")
+
+        parts.append(footer)
+
+        return "\n".join(parts)

--- a/dotflow/providers/notify_telegram.py
+++ b/dotflow/providers/notify_telegram.py
@@ -101,11 +101,7 @@ class NotifyTelegram(Notify):
             parts.append(f"```json\n{task.result(max=4000)}```")
 
         if task.status == TypeStatus.FAILED and task.errors:
-            last_error = (
-                task.errors[-1]
-                if isinstance(task.errors, list)
-                else task.errors
-            )
+            last_error = task.errors[-1]
             parts.append(f"`{last_error.exception}`: {last_error.message}")
 
         parts.append(footer)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -232,6 +232,7 @@ nav:
         - Notify:
           - nav/tutorial/notify-default.md
           - nav/tutorial/notify-telegram.md
+          - nav/tutorial/notify-discord.md
         - Log:
           - nav/tutorial/log-default.md
         - Scheduler:
@@ -277,6 +278,8 @@ nav:
         - nav/tutorial/storage-gcs.md
       - Telegram:
         - nav/tutorial/notify-telegram.md
+      - Discord:
+        - nav/tutorial/notify-discord.md
       - Built-in:
         - nav/tutorial/storage-default.md
         - nav/tutorial/storage-file.md
@@ -306,6 +309,7 @@ nav:
       - Providers:
         - nav/reference/log-default.md
         - nav/reference/notify-default.md
+        - nav/reference/notify-discord.md
         - nav/reference/notify-telegram.md
         - nav/reference/scheduler-default.md
         - nav/reference/scheduler-cron.md

--- a/tests/providers/test_notify_default.py
+++ b/tests/providers/test_notify_default.py
@@ -1,0 +1,22 @@
+"""Test NotifyDefault"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from dotflow.abc.notify import Notify
+from dotflow.providers.notify_default import NotifyDefault
+
+
+class TestNotifyDefault(unittest.TestCase):
+    def test_instance(self):
+        notify = NotifyDefault()
+
+        self.assertIsInstance(notify, Notify)
+
+    def test_hook_status_task_does_nothing(self):
+        notify = NotifyDefault()
+        task = MagicMock()
+
+        result = notify.hook_status_task(task=task)
+
+        self.assertIsNone(result)

--- a/tests/providers/test_notify_discord.py
+++ b/tests/providers/test_notify_discord.py
@@ -1,0 +1,144 @@
+"""Test NotifyDiscord"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from dotflow.abc.notify import Notify
+from dotflow.core.types.status import TypeStatus
+from dotflow.providers.notify_discord import NotifyDiscord
+
+
+class TestNotifyDiscord(unittest.TestCase):
+    def _make_task(self, status=TypeStatus.COMPLETED):
+        task = MagicMock()
+        task.status = status
+        task.workflow_id = "wf-123"
+        task.task_id = 0
+        task.errors = []
+        task.result.return_value = '{"foo": "bar"}'
+        return task
+
+    def test_instance(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test"
+        )
+
+        self.assertIsInstance(notify, Notify)
+
+    def test_default_params(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test"
+        )
+
+        self.assertIsNone(notify.notification_type)
+        self.assertFalse(notify.show_result)
+        self.assertEqual(notify.timeout, 1.5)
+
+    def test_skips_when_status_does_not_match(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test",
+            notification_type=TypeStatus.FAILED,
+        )
+        task = self._make_task(status=TypeStatus.COMPLETED)
+
+        with patch("dotflow.providers.notify_discord.post") as mock_post:
+            notify.hook_status_task(task=task)
+
+        mock_post.assert_not_called()
+
+    def test_sends_when_status_matches(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test",
+            notification_type=TypeStatus.COMPLETED,
+        )
+        task = self._make_task(status=TypeStatus.COMPLETED)
+
+        with patch("dotflow.providers.notify_discord.post") as mock_post:
+            mock_post.return_value.raise_for_status = MagicMock()
+            notify.hook_status_task(task=task)
+
+        mock_post.assert_called_once()
+
+    def test_sends_when_no_filter(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test"
+        )
+        task = self._make_task(status=TypeStatus.COMPLETED)
+
+        with patch("dotflow.providers.notify_discord.post") as mock_post:
+            mock_post.return_value.raise_for_status = MagicMock()
+            notify.hook_status_task(task=task)
+
+        mock_post.assert_called_once()
+
+    def test_build_embed_basic(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test"
+        )
+        task = self._make_task()
+
+        embed = notify._build_embed(task)
+
+        self.assertIn("Completed", embed["title"])
+        self.assertEqual(embed["color"], 0x4CAF50)
+        self.assertIn("wf-123", embed["description"])
+
+    def test_build_embed_without_result(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test"
+        )
+        task = self._make_task()
+
+        embed = notify._build_embed(task)
+
+        field_names = [f["name"] for f in embed["fields"]]
+        self.assertNotIn("Result", field_names)
+
+    def test_build_embed_with_result(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test",
+            show_result=True,
+        )
+        task = self._make_task()
+
+        embed = notify._build_embed(task)
+
+        field_names = [f["name"] for f in embed["fields"]]
+        self.assertIn("Result", field_names)
+
+    def test_build_embed_with_error(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test"
+        )
+        task = self._make_task(status=TypeStatus.FAILED)
+        error = MagicMock()
+        error.exception = "ValueError"
+        error.message = "something broke"
+        task.errors = [error]
+
+        embed = notify._build_embed(task)
+
+        field_names = [f["name"] for f in embed["fields"]]
+        self.assertIn("Error", field_names)
+
+    def test_color_mapping(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test"
+        )
+
+        self.assertEqual(notify.COLORS[TypeStatus.COMPLETED], 0x4CAF50)
+        self.assertEqual(notify.COLORS[TypeStatus.FAILED], 0xF44336)
+        self.assertEqual(notify.COLORS[TypeStatus.RETRY], 0xFF9800)
+
+    def test_logs_on_request_failure(self):
+        notify = NotifyDiscord(
+            webhook_url="https://discord.com/api/webhooks/test"
+        )
+        task = self._make_task()
+
+        with patch("dotflow.providers.notify_discord.post") as mock_post:
+            mock_post.side_effect = Exception("connection error")
+            with patch("dotflow.providers.notify_discord.logger") as mock_log:
+                notify.hook_status_task(task=task)
+
+        mock_log.error.assert_called_once()

--- a/tests/providers/test_notify_telegram.py
+++ b/tests/providers/test_notify_telegram.py
@@ -1,0 +1,107 @@
+"""Test NotifyTelegram"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from dotflow.abc.notify import Notify
+from dotflow.core.types.status import TypeStatus
+from dotflow.providers.notify_telegram import NotifyTelegram
+
+
+class TestNotifyTelegram(unittest.TestCase):
+    def _make_task(self, status=TypeStatus.COMPLETED):
+        task = MagicMock()
+        task.status = status
+        task.workflow_id = "wf-123"
+        task.task_id = 0
+        task.errors = []
+        task.result.return_value = '{"foo": "bar"}'
+        return task
+
+    def test_instance(self):
+        notify = NotifyTelegram(token="tok", chat_id=123)
+
+        self.assertIsInstance(notify, Notify)
+
+    def test_default_params(self):
+        notify = NotifyTelegram(token="tok", chat_id=123)
+
+        self.assertIsNone(notify.notification_type)
+        self.assertFalse(notify.show_result)
+        self.assertEqual(notify.timeout, 1.5)
+
+    def test_skips_when_status_does_not_match(self):
+        notify = NotifyTelegram(
+            token="tok", chat_id=123, notification_type=TypeStatus.FAILED
+        )
+        task = self._make_task(status=TypeStatus.COMPLETED)
+
+        with patch("dotflow.providers.notify_telegram.post") as mock_post:
+            notify.hook_status_task(task=task)
+
+        mock_post.assert_not_called()
+
+    def test_sends_when_status_matches(self):
+        notify = NotifyTelegram(
+            token="tok", chat_id=123, notification_type=TypeStatus.COMPLETED
+        )
+        task = self._make_task(status=TypeStatus.COMPLETED)
+
+        with patch("dotflow.providers.notify_telegram.post") as mock_post:
+            mock_post.return_value.raise_for_status = MagicMock()
+            notify.hook_status_task(task=task)
+
+        mock_post.assert_called_once()
+
+    def test_sends_when_no_filter(self):
+        notify = NotifyTelegram(token="tok", chat_id=123)
+        task = self._make_task(status=TypeStatus.COMPLETED)
+
+        with patch("dotflow.providers.notify_telegram.post") as mock_post:
+            mock_post.return_value.raise_for_status = MagicMock()
+            notify.hook_status_task(task=task)
+
+        mock_post.assert_called_once()
+
+    def test_build_message_without_result(self):
+        notify = NotifyTelegram(token="tok", chat_id=123)
+        task = self._make_task()
+
+        message = notify._build_message(task)
+
+        self.assertIn("Completed", message)
+        self.assertIn("wf-123", message)
+        self.assertNotIn("json", message)
+
+    def test_build_message_with_result(self):
+        notify = NotifyTelegram(token="tok", chat_id=123, show_result=True)
+        task = self._make_task()
+
+        message = notify._build_message(task)
+
+        self.assertIn("json", message)
+        self.assertIn("foo", message)
+
+    def test_build_message_with_error(self):
+        notify = NotifyTelegram(token="tok", chat_id=123)
+        task = self._make_task(status=TypeStatus.FAILED)
+        error = MagicMock()
+        error.exception = "ValueError"
+        error.message = "something broke"
+        task.errors = [error]
+
+        message = notify._build_message(task)
+
+        self.assertIn("ValueError", message)
+        self.assertIn("something broke", message)
+
+    def test_logs_on_request_failure(self):
+        notify = NotifyTelegram(token="tok", chat_id=123)
+        task = self._make_task()
+
+        with patch("dotflow.providers.notify_telegram.post") as mock_post:
+            mock_post.side_effect = Exception("connection error")
+            with patch("dotflow.providers.notify_telegram.logger") as mock_log:
+                notify.hook_status_task(task=task)
+
+        mock_log.error.assert_called_once()


### PR DESCRIPTION
## Description

- `dotflow/abc/notify.py` — Rename `send()` to `hook_status_task()`
- `dotflow/providers/notify_discord.py` — New Discord webhook notification provider
- `dotflow/providers/notify_telegram.py` — Refactored with `show_result`, `_build_message`, error details
- `dotflow/providers/notify_default.py` — Renamed method
- `dotflow/providers/__init__.py` — Export `NotifyDiscord`
- `dotflow/core/task.py` — Updated caller to `hook_status_task`
- Tests for NotifyDefault, NotifyTelegram, NotifyDiscord
- Docs updated across README, tutorials, integrations, custom-providers, mkdocs nav

## Motivation and Context

Closes #184. Adds Discord webhook support following the same pattern as NotifyTelegram. The `send()` method was renamed to `hook_status_task()` to better describe when it is called.

## Types of changes

- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [x] I have updated the documentation accordingly