### PR TITLE
⚙️ FEATURE-#186: Add warning/debug log levels with generic **kwargs to Log ABC

### DIFF
--- a/dotflow/abc/log.py
+++ b/dotflow/abc/log.py
@@ -1,16 +1,21 @@
-"""Notify ABC"""
+"""Log ABC"""
 
 from abc import ABC, abstractmethod
-from typing import Any
 
 
 class Log(ABC):
     """Log"""
 
     @abstractmethod
-    def info(self, task: Any) -> None:
+    def info(self, **kwargs) -> None:
         """Info"""
 
     @abstractmethod
-    def error(self, task: Any) -> None:
+    def error(self, **kwargs) -> None:
         """Error"""
+
+    def warning(self, **kwargs) -> None:
+        """Warning"""
+
+    def debug(self, **kwargs) -> None:
+        """Debug"""

--- a/dotflow/core/task.py
+++ b/dotflow/core/task.py
@@ -208,8 +208,6 @@ class Task(TaskInstance):
         elif isinstance(value, Exception):
             self._errors.append(TaskError(value))
 
-        self.config.log.error(task=self)
-
     @property
     def error(self):
         import warnings
@@ -249,7 +247,13 @@ class Task(TaskInstance):
         self._status = value
 
         self.config.notify.hook_status_task(task=self)
-        self.config.log.info(task=self)
+
+        if value == TypeStatus.FAILED:
+            self.config.log.error(task=self)
+        elif value == TypeStatus.RETRY:
+            self.config.log.warning(task=self)
+        else:
+            self.config.log.info(task=self)
 
     @property
     def config(self):

--- a/dotflow/providers/log_default.py
+++ b/dotflow/providers/log_default.py
@@ -1,25 +1,55 @@
-"""Notify Default"""
-
-from typing import Any
+"""Log Default"""
 
 from dotflow.abc.log import Log
 from dotflow.logging import logger
 
 
 class LogDefault(Log):
-    def info(self, task: Any) -> None:
-        logger.info(
-            "ID %s - %s - %s",
-            task.workflow_id,
-            task.task_id,
-            task.status,
-        )
+    def info(self, **kwargs) -> None:
+        task = kwargs.get("task")
+        if task:
+            logger.info(
+                "ID %s - %s - %s",
+                task.workflow_id,
+                task.task_id,
+                task.status,
+            )
+        else:
+            logger.info("%s", kwargs)
 
-    def error(self, task: Any) -> None:
-        logger.error(
-            "ID %s - %s - %s \n %s",
-            task.workflow_id,
-            task.task_id,
-            task.status,
-            task.errors[-1].traceback if task.errors else "",
-        )
+    def error(self, **kwargs) -> None:
+        task = kwargs.get("task")
+        if task:
+            logger.error(
+                "ID %s - %s - %s \n %s",
+                task.workflow_id,
+                task.task_id,
+                task.status,
+                task.errors[-1].traceback if task.errors else "",
+            )
+        else:
+            logger.error("%s", kwargs)
+
+    def warning(self, **kwargs) -> None:
+        task = kwargs.get("task")
+        if task:
+            logger.warning(
+                "ID %s - %s - %s",
+                task.workflow_id,
+                task.task_id,
+                task.status,
+            )
+        else:
+            logger.warning("%s", kwargs)
+
+    def debug(self, **kwargs) -> None:
+        task = kwargs.get("task")
+        if task:
+            logger.debug(
+                "ID %s - %s - %s",
+                task.workflow_id,
+                task.task_id,
+                task.status,
+            )
+        else:
+            logger.debug("%s", kwargs)


### PR DESCRIPTION
## Description

- `dotflow/abc/log.py` — Add `warning()` and `debug()` methods, change all signatures to `**kwargs`
- `dotflow/providers/log_default.py` — Implement all 4 log levels with task detection via `kwargs.get("task")`
- `dotflow/core/task.py` — Use `warning` for RETRY, `error` for FAILED, `info` for rest. Remove duplicate log from errors setter.

## Motivation and Context

The Log ABC only had `info()` and `error()` with a fixed `task` parameter. This change adds `warning` and `debug` levels, and makes all methods accept generic `**kwargs` so they can be used for task, workflow, or any other context.

Closes #186

## Types of changes

- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly