### PR TITLE
🪲 BUG-#215: Fix StorageFile.get() returning empty list for missing keys

### DIFF
--- a/dotflow/providers/storage_file.py
+++ b/dotflow/providers/storage_file.py
@@ -44,6 +44,9 @@ class StorageFile(Storage):
         if Path(self.path, key).exists():
             task_context = read_file(path=Path(self.path, key))
 
+        if not task_context:
+            return Context()
+
         if len(task_context) == 1:
             return self._loads(storage=task_context[0])
 


### PR DESCRIPTION
# Description

Fix `StorageFile.get()` returning `Context(storage=[])` instead of `Context()` when a key does not exist. This broke `resume=True` — all tasks were silently skipped because `[] is not None` evaluates `True`.

Issue: [📌 ISSUE-#215](https://github.com/dotflow-io/dotflow/issues/215)

## Changes

- Add early return `Context()` when `task_context` is empty in `StorageFile.get()`
- Aligns with the pattern already used by `StorageS3` and `StorageGCS`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes