### PR TITLE
🪲 BUG-#217: Fix SerializerTask.model_dump_json() mutating self and truncating JSON

### DIFF
--- a/dotflow/core/serializers/task.py
+++ b/dotflow/core/serializers/task.py
@@ -46,17 +46,10 @@ class SerializerTask(BaseModel):
         dump_json = json.dumps(data)
 
         if self.max and len(dump_json) > self.max:
-            self.initial_context = self.size_message
-            self.current_context = self.size_message
-            self.previous_context = self.size_message
-
-            data = json.loads(
-                super().model_dump_json(serialize_as_any=True, **kwargs)
-            )
-            data["error"] = data["errors"][-1] if data["errors"] else None
+            data["initial_context"] = self.size_message
+            data["current_context"] = self.size_message
+            data["previous_context"] = self.size_message
             dump_json = json.dumps(data)
-
-            return dump_json[0 : self.max]
 
         return dump_json
 

--- a/dotflow/core/serializers/task.py
+++ b/dotflow/core/serializers/task.py
@@ -51,6 +51,11 @@ class SerializerTask(BaseModel):
             data["previous_context"] = self.size_message
             dump_json = json.dumps(data)
 
+            if len(dump_json) > self.max:
+                data["errors"] = []
+                data["error"] = None
+                dump_json = json.dumps(data)
+
         return dump_json
 
     @field_validator("errors", mode="before")

--- a/tests/core/test_serializer_task.py
+++ b/tests/core/test_serializer_task.py
@@ -1,0 +1,91 @@
+"""Test SerializerTask model_dump_json"""
+
+import json
+import unittest
+
+from dotflow.core.context import Context
+from dotflow.core.serializers.task import SerializerTask
+
+
+class TestSerializerTaskDumpJson(unittest.TestCase):
+
+    def _make_task(self, **kwargs):
+        defaults = {
+            "task_id": 0,
+            "_status": "Completed",
+            "_duration": 1.5,
+            "_initial_context": None,
+            "_current_context": None,
+            "_previous_context": None,
+            "group_name": "default",
+            "retry_count": 0,
+            "_errors": [],
+        }
+        defaults.update(kwargs)
+        return SerializerTask(**defaults)
+
+    def test_returns_valid_json(self):
+        task = self._make_task()
+        result = task.model_dump_json()
+
+        parsed = json.loads(result)
+        self.assertEqual(parsed["task_id"], 0)
+        self.assertEqual(parsed["status"], "Completed")
+
+    def test_with_max_does_not_mutate_self(self):
+        ctx = Context(storage={"large": "x" * 500})
+        task = self._make_task(_initial_context=ctx, max=100)
+
+        task.model_dump_json()
+        task.model_dump_json()
+
+        self.assertNotEqual(task.initial_context, task.size_message)
+
+    def test_with_max_returns_valid_json(self):
+        ctx = Context(storage={"large": "x" * 500})
+        task = self._make_task(_initial_context=ctx, max=100)
+
+        result = task.model_dump_json()
+        json.loads(result)
+
+    def test_with_max_replaces_contexts(self):
+        task = self._make_task(
+            _initial_context=Context(storage={"large": "x" * 500}),
+            _current_context=Context(storage={"large": "y" * 500}),
+            _previous_context=Context(storage={"large": "z" * 500}),
+            max=200,
+        )
+
+        result = task.model_dump_json()
+        parsed = json.loads(result)
+
+        self.assertEqual(parsed["initial_context"], "Context size exceeded")
+        self.assertEqual(parsed["current_context"], "Context size exceeded")
+        self.assertEqual(parsed["previous_context"], "Context size exceeded")
+
+    def test_with_max_clears_errors_if_still_over(self):
+        large_errors = [
+            {
+                "attempt": i,
+                "exception": "Error",
+                "traceback": "x" * 500,
+                "message": "fail",
+            }
+            for i in range(10)
+        ]
+        task = self._make_task(_errors=large_errors, max=200)
+
+        result = task.model_dump_json()
+        parsed = json.loads(result)
+
+        self.assertEqual(parsed["errors"], [])
+        self.assertIsNone(parsed["error"])
+
+    def test_without_max_returns_full_json(self):
+        ctx = Context(storage={"large": "x" * 500})
+        task = self._make_task(_initial_context=ctx)
+
+        result = task.model_dump_json()
+        parsed = json.loads(result)
+
+        self.assertIn("large", str(parsed["initial_context"]))

--- a/tests/core/test_serializer_task.py
+++ b/tests/core/test_serializer_task.py
@@ -8,7 +8,6 @@ from dotflow.core.serializers.task import SerializerTask
 
 
 class TestSerializerTaskDumpJson(unittest.TestCase):
-
     def _make_task(self, **kwargs):
         defaults = {
             "task_id": 0,


### PR DESCRIPTION
## Description

Fix two bugs in `SerializerTask.model_dump_json()` in `dotflow/core/serializers/task.py`:

1. **Self mutation** — context fields were replaced on `self` instead of the local dict, permanently losing original data on repeated calls
2. **Truncated JSON** — `dump_json[0:self.max]` cut JSON mid-string, producing invalid output

## Motivation and Context

Fixes issue #217 — `model_dump_json()` was mutating `self` and producing invalid truncated JSON

## Changes

- Replace `self.initial_context = ...` with `data["initial_context"] = ...` (operates on local dict)
- Remove `dump_json[0:self.max]` truncation (contexts replaced with size message is enough to reduce size)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Tests added
- [ ] CHANGELOG updated
- [ ] Documentation updated