### PR TITLE
🪲 BUG-#216: Fix traceback_error ignoring error parameter

### DIFF
--- a/dotflow/utils/error_handler.py
+++ b/dotflow/utils/error_handler.py
@@ -1,21 +1,12 @@
 """Error handler module"""
 
-import sys
 import traceback
 
 
 def traceback_error(error: Exception) -> str:
-    exception_list = traceback.format_stack()
-    exception_list = exception_list[:-2]
-    exception_list.extend(traceback.format_tb(sys.exc_info()[2]))
-    exception_list.extend(
-        traceback.format_exception_only(sys.exc_info()[0], sys.exc_info()[1])
-    )
-
-    message = "".join(exception_list)
-    message = message[:-1]
-
-    return message
+    return "".join(
+        traceback.format_exception(type(error), error, error.__traceback__)
+    ).rstrip()
 
 
 def message_error(error: Exception) -> str:

--- a/tests/utils/test_error_handler.py
+++ b/tests/utils/test_error_handler.py
@@ -1,0 +1,49 @@
+"""Test error handler"""
+
+import unittest
+
+from dotflow.utils.error_handler import message_error, traceback_error
+
+
+class TestTracebackError(unittest.TestCase):
+    def test_returns_traceback_from_error_parameter(self):
+        try:
+            1 / 0
+        except ZeroDivisionError as e:
+            saved_error = e
+
+        result = traceback_error(saved_error)
+
+        self.assertIn("ZeroDivisionError", result)
+        self.assertIn("division by zero", result)
+
+    def test_works_outside_except_block(self):
+        try:
+            raise ValueError("test error")
+        except ValueError as e:
+            saved_error = e
+
+        result = traceback_error(saved_error)
+
+        self.assertIn("ValueError", result)
+        self.assertIn("test error", result)
+
+    def test_includes_traceback_lines(self):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as e:
+            saved_error = e
+
+        result = traceback_error(saved_error)
+
+        self.assertIn("Traceback", result)
+        self.assertIn("RuntimeError: boom", result)
+
+
+class TestMessageError(unittest.TestCase):
+    def test_returns_error_message(self):
+        error = ValueError("something went wrong")
+
+        result = message_error(error)
+
+        self.assertEqual(result, "something went wrong")

--- a/tests/utils/test_error_handler.py
+++ b/tests/utils/test_error_handler.py
@@ -8,7 +8,7 @@ from dotflow.utils.error_handler import message_error, traceback_error
 class TestTracebackError(unittest.TestCase):
     def test_returns_traceback_from_error_parameter(self):
         try:
-            1 / 0
+            _ = 1 / 0
         except ZeroDivisionError as e:
             saved_error = e
 


### PR DESCRIPTION
# Description

Fix `traceback_error()` which accepted an `error` parameter but never used it, relying on `sys.exc_info()` instead. This produced empty/wrong tracebacks when called outside an active `except` block.

Issue: [📌 ISSUE-#216](https://github.com/dotflow-io/dotflow/issues/216)

## Changes

- Replace `sys.exc_info()` + `format_stack()` with `traceback.format_exception(type(error), error, error.__traceback__)`
- Remove unused `import sys`
- Traceback now always reflects the actual error, regardless of call context

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes