### PR TITLE
🪲 BUG-#204: Replace unsafe ctypes memory access in StorageDefault

### DIFF
--- a/dotflow/providers/storage_default.py
+++ b/dotflow/providers/storage_default.py
@@ -1,20 +1,22 @@
 """Storage Default"""
 
 from collections.abc import Callable
-from ctypes import cast, py_object
 
 from dotflow.abc.storage import Storage
 from dotflow.core.context import Context
 
 
 class StorageDefault(Storage):
-    """Storage"""
+    """In-memory storage using a dictionary."""
+
+    def __init__(self):
+        self._store: dict[str, Context] = {}
 
     def post(self, key: str, context: Context) -> None:
-        return None
+        self._store[key] = context
 
     def get(self, key: str) -> Context:
-        return Context(storage=cast(key, py_object).value)
+        return self._store.get(key, Context())
 
-    def key(self, task: Callable):
-        return id(task.current_context)
+    def key(self, task: Callable) -> str:
+        return f"{task.workflow_id}-{task.task_id}"

--- a/tests/providers/test_storage_default.py
+++ b/tests/providers/test_storage_default.py
@@ -42,16 +42,27 @@ class TestStorageDefault(unittest.TestCase):
 
         self.assertEqual(key, f"{task.workflow_id}-{task.task_id}")
 
-    def test_get_with_task_context(self):
+    def test_post_overwrites_previous_value(self):
+        storage = StorageDefault()
+
+        storage.post(key="k", context=Context(storage="first"))
+        storage.post(key="k", context=Context(storage="second"))
+        result = storage.get(key="k")
+
+        self.assertEqual(result.storage, "second")
+
+    def test_post_and_get_with_task(self):
+        storage = StorageDefault()
         task = Task(
             task_id=0,
             workflow_id=uuid4(),
             step=action_step,
         )
-        task.current_context = "flow"
 
-        storage = StorageDefault()
         key = storage.key(task=task)
+        context = Context(storage="flow")
+        storage.post(key=key, context=context)
         result = storage.get(key=key)
 
         self.assertIsInstance(result, Context)
+        self.assertEqual(result.storage, "flow")

--- a/tests/providers/test_storage_default.py
+++ b/tests/providers/test_storage_default.py
@@ -1,4 +1,4 @@
-"""Test StorageFile"""
+"""Test StorageDefault"""
 
 import unittest
 from uuid import uuid4
@@ -13,18 +13,45 @@ class TestStorageDefault(unittest.TestCase):
     def test_storage_default_instance(self):
         StorageDefault()
 
-    def test_get(self):
-        expected_value = "flow"
+    def test_post_and_get_roundtrip(self):
+        storage = StorageDefault()
+        context = Context(storage={"data": 42})
 
+        storage.post(key="test-key", context=context)
+        result = storage.get(key="test-key")
+
+        self.assertIsInstance(result, Context)
+        self.assertEqual(result.storage, {"data": 42})
+
+    def test_get_missing_key_returns_empty_context(self):
+        storage = StorageDefault()
+        result = storage.get(key="nonexistent")
+
+        self.assertIsInstance(result, Context)
+        self.assertIsNone(result.storage)
+
+    def test_key_format(self):
         task = Task(
             task_id=0,
             workflow_id=uuid4(),
             step=action_step,
         )
-        task.current_context = expected_value
 
         storage = StorageDefault()
-        result = storage.get(key=storage.key(task=task))
+        key = storage.key(task=task)
+
+        self.assertEqual(key, f"{task.workflow_id}-{task.task_id}")
+
+    def test_get_with_task_context(self):
+        task = Task(
+            task_id=0,
+            workflow_id=uuid4(),
+            step=action_step,
+        )
+        task.current_context = "flow"
+
+        storage = StorageDefault()
+        key = storage.key(task=task)
+        result = storage.get(key=key)
 
         self.assertIsInstance(result, Context)
-        self.assertEqual(result.storage, expected_value)


### PR DESCRIPTION
# Description

Replace `ctypes.cast(id, py_object)` with a safe dict-based in-memory storage in `StorageDefault`.

Issue: [📌 ISSUE-#204](https://github.com/dotflow-io/dotflow/issues/204)

## Changes

- `post()` — now stores context in `_store` dict (was no-op returning `None`)
- `get()` — retrieves from dict, returns `Context()` for missing keys (was `ctypes.cast` on memory address)
- `key()` — returns `f"{workflow_id}-{task_id}"` consistent with S3/GCS/File (was `id()` memory address)
- Removed `ctypes` import
- Updated tests with roundtrip, missing key, and key format assertions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes