### PR TITLE
🪲 BUG-#208: Replace spec_from_file_location with importlib.import_module

### DIFF
--- a/dotflow/core/module.py
+++ b/dotflow/core/module.py
@@ -1,8 +1,6 @@
 """Task module"""
 
-import sys
-from importlib.util import module_from_spec
-from importlib.util import spec_from_file_location as file_location
+import importlib
 from typing import Any
 
 from dotflow.core.exception import ImportModuleError
@@ -16,21 +14,17 @@ class Module:
 
     @classmethod
     def import_module(cls, value: str):
-        spec = file_location(value, cls._get_path(value))
-        module = module_from_spec(spec)
+        module_path, _, attr_name = value.rpartition(".")
 
-        sys.modules[module.__name__] = module
-        spec.loader.exec_module(module)
+        if not module_path:
+            raise ImportModuleError(module=value)
 
-        if hasattr(module, cls._get_name(value)):
-            return getattr(module, cls._get_name(value))
+        try:
+            module = importlib.import_module(module_path)
+        except ModuleNotFoundError:
+            raise ImportModuleError(module=value) from None
+
+        if hasattr(module, attr_name):
+            return getattr(module, attr_name)
 
         raise ImportModuleError(module=value)
-
-    @classmethod
-    def _get_name(cls, value: str):
-        return value.split(".")[-1:][0]
-
-    @classmethod
-    def _get_path(cls, value: str):
-        return f"{'/'.join(value.split('.')[:-1])}.py"


### PR DESCRIPTION
# Description

Replace manual filesystem-based module loading with `importlib.import_module()` in the `Module` class.

Issue: [📌 ISSUE-#208](https://github.com/dotflow-io/dotflow/issues/208)

## Changes

- Replace `spec_from_file_location` + `module_from_spec` + `sys.modules` with `importlib.import_module()`
- Remove `_get_path` and `_get_name` helper methods
- Use `str.rpartition(".")` to split module path from attribute name
- Works with installed packages, namespace packages, zip imports, any CWD

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes