### PR TITLE
🪲 BUG-#221: Fix StorageFile crash on corrupted task files

### DIFF
--- a/dotflow/providers/storage_file.py
+++ b/dotflow/providers/storage_file.py
@@ -30,13 +30,9 @@ class StorageFile(Storage):
             for item in context.storage:
                 if isinstance(item, Context):
                     task_context.append(self._dumps(storage=item.storage))
+        else:
+            task_context.append(self._dumps(storage=context.storage))
 
-            write_file(
-                path=Path(self.path, key), content=task_context, mode="a"
-            )
-            return None
-
-        task_context.append(self._dumps(storage=context.storage))
         write_file(path=Path(self.path, key), content=task_context)
         return None
 

--- a/dotflow/providers/storage_file.py
+++ b/dotflow/providers/storage_file.py
@@ -22,7 +22,9 @@ class StorageFile(Storage):
         task_context = []
 
         if Path(self.path, key).exists():
-            task_context = read_file(path=Path(self.path, key))
+            data = read_file(path=Path(self.path, key))
+            if isinstance(data, list):
+                task_context = data
 
         if isinstance(context.storage, list):
             for item in context.storage:
@@ -42,7 +44,9 @@ class StorageFile(Storage):
         task_context = []
 
         if Path(self.path, key).exists():
-            task_context = read_file(path=Path(self.path, key))
+            data = read_file(path=Path(self.path, key))
+            if isinstance(data, list):
+                task_context = data
 
         if not task_context:
             return Context()

--- a/tests/providers/test_storage_file.py
+++ b/tests/providers/test_storage_file.py
@@ -119,6 +119,43 @@ class TestStorageFile(unittest.TestCase):
         self.assertEqual(result.storage[0].storage, expected_value_one)
         self.assertEqual(result.storage[1].storage, expected_value_two)
 
+    def test_post_with_corrupted_file(self):
+        self.path.joinpath("tasks").mkdir()
+
+        with open(
+            file=self.path.joinpath("tasks", self.file_name), mode="w"
+        ) as file:
+            file.write("not valid json {{{")
+
+        storage = StorageFile(path=self.path)
+        storage.post(
+            key=self.file_name, context=Context(storage={"new": "data"})
+        )
+
+        result = storage.get(key=self.file_name)
+        self.assertEqual(result.storage, {"new": "data"})
+
+    def test_get_with_corrupted_file(self):
+        self.path.joinpath("tasks").mkdir()
+
+        with open(
+            file=self.path.joinpath("tasks", self.file_name), mode="w"
+        ) as file:
+            file.write("corrupted content")
+
+        storage = StorageFile(path=self.path)
+        result = storage.get(key=self.file_name)
+
+        self.assertIsInstance(result, Context)
+        self.assertIsNone(result.storage)
+
+    def test_get_missing_file(self):
+        storage = StorageFile(path=self.path)
+        result = storage.get(key="nonexistent.json")
+
+        self.assertIsInstance(result, Context)
+        self.assertIsNone(result.storage)
+
     def test_key(self):
         workflow_id = uuid4()
 


### PR DESCRIPTION
# Description

Fix `StorageFile.post()` and `StorageFile.get()` crashing with `AttributeError` when task files contain non-JSON content (corrupted, interrupted writes, manual edits).

Issue: [📌 ISSUE-#221](https://github.com/dotflow-io/dotflow/issues/221)

## Changes

- Validate `read_file` return type in both `post()` and `get()` — only use result if it's a `list`
- Corrupted files are silently treated as empty (overwritten on next write)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes