### PR TITLE
🪲 BUG-#219: Replace hardcoded TEMPLATE_REPO with Settings constant

### DIFF
--- a/dotflow/cli/commands/init.py
+++ b/dotflow/cli/commands/init.py
@@ -6,12 +6,10 @@ from rich import print  # type: ignore
 from dotflow.cli.command import Command
 from dotflow.settings import Settings as settings
 
-TEMPLATE_REPO = "https://github.com/dotflow-io/template"
-
 
 class InitCommand(Command):
     def setup(self):
-        cookiecutter(TEMPLATE_REPO)
+        cookiecutter(settings.TEMPLATE_REPO)
 
         print(
             settings.INFO_ALERT,

--- a/dotflow/settings.py
+++ b/dotflow/settings.py
@@ -17,7 +17,7 @@ class Settings:
     LOG_PATH = _OUTPUT / "flow.log"
     LOG_FORMAT = "%(asctime)s - %(levelname)s [%(name)s]: %(message)s"
 
-    TEMPLATE_REPO = "https://github.com/dotflow-io/template.git"
+    TEMPLATE_REPO = "https://github.com/dotflow-io/templates.git"
     TEMPLATE_BRANCH = "master"
     TEMPLATE_CLOUD_DIR = "cloud"
 


### PR DESCRIPTION
# Description

Replace hardcoded `TEMPLATE_REPO` in `init.py` with `settings.TEMPLATE_REPO` from `dotflow/settings.py`.

Issue: [📌 ISSUE-#219](https://github.com/dotflow-io/dotflow/issues/219)

## Changes

- Remove local `TEMPLATE_REPO` constant from `dotflow/cli/commands/init.py`
- Use `settings.TEMPLATE_REPO` (already imported)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings