### PR TITLE
🪲 BUG-#218: Fix CLI --storage s3/gcs crash with missing bucket argument

### DIFF
--- a/dotflow/cli/commands/storage.py
+++ b/dotflow/cli/commands/storage.py
@@ -1,0 +1,55 @@
+"""Storage resolver for CLI commands"""
+
+from dotflow.providers import (
+    StorageDefault,
+    StorageFile,
+    StorageGCS,
+    StorageS3,
+)
+from dotflow.settings import Settings as settings
+
+
+class StorageResolver:
+    """Resolves a storage provider instance from CLI params."""
+
+    def __init__(self, params):
+        self.params = params
+
+    def resolve(self):
+        """Returns a storage instance or None if no --storage was specified."""
+        if not self.params.storage:
+            return None
+
+        resolvers = {
+            "default": self._resolve_local,
+            "file": self._resolve_local,
+            "s3": self._resolve_s3,
+            "gcs": self._resolve_gcs,
+        }
+
+        resolver = resolvers.get(self.params.storage)
+        if resolver is None:
+            return None
+
+        return resolver()
+
+    def _resolve_local(self):
+        storage_cls = {"default": StorageDefault, "file": StorageFile}
+        return storage_cls[self.params.storage](path=self.params.path)
+
+    def _resolve_s3(self):
+        self._require("bucket")
+        return StorageS3(bucket=self.params.bucket, region=self.params.region)
+
+    def _resolve_gcs(self):
+        self._require("bucket")
+        return StorageGCS(
+            bucket=self.params.bucket, project=self.params.gcp_project
+        )
+
+    def _require(self, arg):
+        if not getattr(self.params, arg, None):
+            raise SystemExit(
+                f"{settings.ERROR_ALERT} --storage {self.params.storage}"
+                f" requires --{arg}"
+            )


### PR DESCRIPTION
# Description

Fix `dotflow start --storage s3` and `dotflow start --storage gcs` crashing with `TypeError` due to missing `bucket` argument.

Issue: [📌 ISSUE-#218](https://github.com/dotflow-io/dotflow/issues/218)

## Changes

- Add `--bucket`, `--region`, `--gcp-project` arguments to `start` and `schedule` CLI commands
- Update `start.py` and `schedule.py` to pass bucket/region/project to S3/GCS constructors
- Clear error message when `--bucket` is missing for S3/GCS
- Add S3/GCS CLI examples to docs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation updated (documentation was updated and published)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes