### PR TITLE
🪲 BUG-#209: Raise TypeError on invalid Context setter values

### DIFF
--- a/dotflow/core/context.py
+++ b/dotflow/core/context.py
@@ -68,8 +68,14 @@ class Context(ContextInstance):
 
     @task_id.setter
     def task_id(self, value: int):
-        if isinstance(value, int):
-            self._task_id = value
+        if value is None:
+            self._task_id = None
+            return
+        if not isinstance(value, int):
+            raise TypeError(
+                f"task_id must be an int, got {type(value).__name__}: {value!r}"
+            )
+        self._task_id = value
 
     @property
     def workflow_id(self):
@@ -77,6 +83,9 @@ class Context(ContextInstance):
 
     @workflow_id.setter
     def workflow_id(self, value: UUID):
+        if value is None:
+            self._workflow_id = None
+            return
         if isinstance(value, str):
             try:
                 value = UUID(value)
@@ -84,8 +93,12 @@ class Context(ContextInstance):
                 raise ValueError(
                     f"Invalid workflow_id: '{value}' is not a valid UUID format."
                 ) from err
-        if isinstance(value, UUID):
-            self._workflow_id = value
+        if not isinstance(value, UUID):
+            raise TypeError(
+                f"workflow_id must be a UUID or UUID string, "
+                f"got {type(value).__name__}: {value!r}"
+            )
+        self._workflow_id = value
 
     @property
     def storage(self):

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -8,7 +8,6 @@ from dotflow.core.context import Context
 
 
 class TestContext(unittest.TestCase):
-
     def setUp(self):
         self.content = {"foo": "bar"}
 
@@ -26,7 +25,6 @@ class TestContext(unittest.TestCase):
 
 
 class TestContextTaskIdSetter(unittest.TestCase):
-
     def test_valid_int(self):
         ctx = Context(task_id=5)
         self.assertEqual(ctx.task_id, 5)
@@ -50,7 +48,6 @@ class TestContextTaskIdSetter(unittest.TestCase):
 
 
 class TestContextWorkflowIdSetter(unittest.TestCase):
-
     def test_valid_uuid(self):
         uid = uuid4()
         ctx = Context(workflow_id=uid)

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -2,11 +2,13 @@
 
 import unittest
 from datetime import datetime
+from uuid import uuid4
 
 from dotflow.core.context import Context
 
 
 class TestContext(unittest.TestCase):
+
     def setUp(self):
         self.content = {"foo": "bar"}
 
@@ -21,3 +23,57 @@ class TestContext(unittest.TestCase):
 
         self.assertIsInstance(context.time, datetime)
         self.assertEqual(context.storage, self.content)
+
+
+class TestContextTaskIdSetter(unittest.TestCase):
+
+    def test_valid_int(self):
+        ctx = Context(task_id=5)
+        self.assertEqual(ctx.task_id, 5)
+
+    def test_none_is_allowed(self):
+        ctx = Context()
+        ctx.task_id = None
+        self.assertIsNone(ctx.task_id)
+
+    def test_string_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            Context(task_id="5")
+
+    def test_float_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            Context(task_id=3.14)
+
+    def test_list_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            Context(task_id=[1])
+
+
+class TestContextWorkflowIdSetter(unittest.TestCase):
+
+    def test_valid_uuid(self):
+        uid = uuid4()
+        ctx = Context(workflow_id=uid)
+        self.assertEqual(ctx.workflow_id, uid)
+
+    def test_valid_uuid_string(self):
+        uid = uuid4()
+        ctx = Context(workflow_id=str(uid))
+        self.assertEqual(ctx.workflow_id, uid)
+
+    def test_none_is_allowed(self):
+        ctx = Context()
+        ctx.workflow_id = None
+        self.assertIsNone(ctx.workflow_id)
+
+    def test_invalid_uuid_string_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            Context(workflow_id="not-a-uuid")
+
+    def test_int_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            Context(workflow_id=12345)
+
+    def test_list_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            Context(workflow_id=[1, 2, 3])


### PR DESCRIPTION
# Description

Fix Context property setters that silently ignored invalid values, leaving attributes as None.

Issue: [📌 ISSUE-#209](https://github.com/dotflow-io/dotflow/issues/209)

## Changes

- `task_id` setter — raises `TypeError` for non-int values (was silently ignored)
- `workflow_id` setter — raises `TypeError` for non-UUID/non-string values (was silently ignored)
- `None` is explicitly allowed in both setters
- 11 new tests covering valid values, None, and invalid types

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes