### PR TITLE
🪲 BUG-#241: Fix ServerDefault update_task payload and add sequential_group docs

### DIFF
--- a/docs/nav/concepts/process-mode-sequential-group.md
+++ b/docs/nav/concepts/process-mode-sequential-group.md
@@ -6,38 +6,7 @@ This mode is automatically selected when you use `mode="sequential"` with multip
 
 ## Implementation
 
-```python
-from dotflow import DotFlow, action
-
-
-@action
-def step_a():
-    return {"group": "A", "step": 1}
-
-
-@action
-def step_b(previous_context):
-    return {"group": "A", "step": 2}
-
-
-@action
-def step_c():
-    return {"group": "B", "step": 1}
-
-
-@action
-def step_d(previous_context):
-    return {"group": "B", "step": 2}
-
-
-workflow = DotFlow()
-workflow.task.add(step=step_a, group_name="group_a")
-workflow.task.add(step=step_b, group_name="group_a")
-workflow.task.add(step=step_c, group_name="group_b")
-workflow.task.add(step=step_d, group_name="group_b")
-
-workflow.start(mode="sequential_group")
-```
+{* ./docs_src/process_mode/sequential_group.py hl[33] *}
 
 ## Workflow
 

--- a/docs_src/process_mode/sequential_group.py
+++ b/docs_src/process_mode/sequential_group.py
@@ -1,0 +1,38 @@
+from dotflow import DotFlow, action
+
+
+@action
+def step_a():
+    return {"group": "A", "step": 1}
+
+
+@action
+def step_b(previous_context):
+    return {"group": "A", "step": 2}
+
+
+@action
+def step_c():
+    return {"group": "B", "step": 1}
+
+
+@action
+def step_d(previous_context):
+    return {"group": "B", "step": 2}
+
+
+def main():
+    workflow = DotFlow()
+
+    workflow.task.add(step=step_a, group_name="group_a")
+    workflow.task.add(step=step_b, group_name="group_a")
+    workflow.task.add(step=step_c, group_name="group_b")
+    workflow.task.add(step=step_d, group_name="group_b")
+
+    workflow.start(mode="sequential_group")
+
+    return workflow
+
+
+if __name__ == "__main__":
+    main()

--- a/dotflow/core/task.py
+++ b/dotflow/core/task.py
@@ -308,7 +308,7 @@ class TaskBuilder:
         self.queue: list[Callable] = []
         self.workflow_id = workflow_id
         self.config = config
-        self._next_id = 0
+        self._next_id = 1
 
     def add(
         self,

--- a/dotflow/providers/server_default.py
+++ b/dotflow/providers/server_default.py
@@ -104,9 +104,25 @@ class ServerDefault(Server):
         if not self.enabled:
             return
 
+        result = task.result()
+        payload = {
+            k: result.get(k)
+            for k in (
+                "status",
+                "errors",
+                "retry_count",
+                "duration",
+                "current_context",
+                "previous_context",
+                "started_at",
+                "finished_at",
+            )
+            if result.get(k) is not None
+        }
+
         self._request(
             http_patch,
             f"{self.base_url}/workflows/"
             f"{task.workflow_id}/tasks/{task.task_id}",
-            task.result(),
+            payload,
         )

--- a/tests/core/test_task_build.py
+++ b/tests/core/test_task_build.py
@@ -27,7 +27,7 @@ class TestTaskBuild(unittest.TestCase):
         task = TaskBuilder(config=self.config)
         task.add(step=action_step)
 
-        self.assertEqual(task.queue[0].task_id, 0)
+        self.assertEqual(task.queue[0].task_id, 1)
         self.assertIsInstance(task.queue[0], Task)
         self.assertEqual(task.queue[0].callback, basic_callback)
         self.assertEqual(len(task.queue), 1)
@@ -114,7 +114,7 @@ class TestTaskBuild(unittest.TestCase):
             result["workflow_id"],
             str(expected_workflow_id),
         )
-        self.assertEqual(task_result["task_id"], 0)
+        self.assertEqual(task_result["task_id"], 1)
         self.assertEqual(task_result["status"], "Not started")
         self.assertEqual(task_result["duration"], None)
         self.assertEqual(task_result["retry_count"], 0)


### PR DESCRIPTION
## Description

- Fix `ServerDefault.update_task` to send only valid `TaskUpdate` fields instead of full `task.result()` payload
- Fix `_next_id` to start at 1 (MySQL treats id=0 as auto-increment)
- Add debug logging to `_request`
- Add `sequential_group` example in `docs_src/process_mode/`
- Update concept page to reference the example

Closes #241

## Types of changes
- [x] Bug fix
- [x] Documentation

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective