### PR TITLE
🪲 BUG-#245: Fix TimeoutError not caught on Python 3.9/3.10

### DIFF
--- a/dotflow/core/engine.py
+++ b/dotflow/core/engine.py
@@ -2,7 +2,12 @@
 
 import re
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import (
+    ThreadPoolExecutor,
+)
+from concurrent.futures import (
+    TimeoutError as FuturesTimeoutError,
+)
 from contextlib import contextmanager
 from datetime import datetime
 from inspect import getsourcelines
@@ -131,7 +136,7 @@ class TaskEngine:
                 self.task.current_context = result
                 return result
 
-            except TimeoutError:
+            except (TimeoutError, FuturesTimeoutError):
                 raise
 
             except Exception as error:
@@ -173,9 +178,9 @@ class TaskEngine:
         try:
             future = executor.submit(self._execute_single)
             return future.result(timeout=seconds)
-        except TimeoutError:
+        except (TimeoutError, FuturesTimeoutError):
             future.cancel()
-            raise
+            raise TimeoutError() from None
         finally:
             executor.shutdown(wait=False, cancel_futures=True)
 

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -446,11 +446,11 @@ class TestTaskEngine(unittest.TestCase):
 
         self.assertEqual(task.status, TypeStatus.FAILED)
 
-    def test_futures_timeout_error_is_caught(self):
+    def test_futures_timeout_error_converted_to_builtin(self):
         from concurrent.futures import (
             TimeoutError as FuturesTimeoutError,
         )
-        from unittest.mock import patch
+        from unittest.mock import MagicMock, patch
 
         task = Task(
             task_id=0,
@@ -463,14 +463,11 @@ class TestTaskEngine(unittest.TestCase):
             previous_context=Context(),
         )
 
-        with (
-            patch.object(
-                engine,
-                "_execute_with_timeout",
-                side_effect=FuturesTimeoutError("timed out"),
-            ),
-            engine.start(),
-        ):
-            engine.execute_with_retry()
+        mock_future = MagicMock()
+        mock_future.result.side_effect = FuturesTimeoutError("timed out")
 
-        self.assertEqual(task.status, TypeStatus.FAILED)
+        with patch("dotflow.core.engine.ThreadPoolExecutor") as mock_pool:
+            mock_pool.return_value.submit.return_value = mock_future
+
+            with self.assertRaises(TimeoutError):
+                engine._execute_with_timeout(seconds=1)

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -419,3 +419,58 @@ class TestTaskEngine(unittest.TestCase):
             engine.execute_with_retry()
 
         self.assertEqual(task.status, TypeStatus.COMPLETED)
+
+    def test_timeout_expired_marks_task_failed(self):
+        from time import sleep as _sleep
+
+        from dotflow import action
+
+        @action(timeout=1)
+        def slow_step():
+            _sleep(5)
+            return {"done": True}
+
+        task = Task(
+            task_id=0,
+            step=slow_step,
+            callback=simple_callback,
+        )
+        engine = TaskEngine(
+            task=task,
+            workflow_id=self.workflow_id,
+            previous_context=Context(),
+        )
+
+        with engine.start():
+            engine.execute_with_retry()
+
+        self.assertEqual(task.status, TypeStatus.FAILED)
+
+    def test_futures_timeout_error_is_caught(self):
+        from concurrent.futures import (
+            TimeoutError as FuturesTimeoutError,
+        )
+        from unittest.mock import patch
+
+        task = Task(
+            task_id=0,
+            step=action_step_with_timeout,
+            callback=simple_callback,
+        )
+        engine = TaskEngine(
+            task=task,
+            workflow_id=self.workflow_id,
+            previous_context=Context(),
+        )
+
+        with (
+            patch.object(
+                engine,
+                "_execute_with_timeout",
+                side_effect=FuturesTimeoutError("timed out"),
+            ),
+            engine.start(),
+        ):
+            engine.execute_with_retry()
+
+        self.assertEqual(task.status, TypeStatus.FAILED)


### PR DESCRIPTION
## Summary

- Import `concurrent.futures.TimeoutError as FuturesTimeoutError`
- Catch both `TimeoutError` and `FuturesTimeoutError` in `execute_with_retry` (line 136) and `_execute_with_timeout` (line 181)
- Re-raise as `TimeoutError() from None` for clean traceback

## Problem

On Python 3.9/3.10, `concurrent.futures.TimeoutError` is a separate class that does **not** inherit from `builtins.TimeoutError`. The code only caught `TimeoutError` (builtin), so `future.result(timeout=N)` raised an uncaught exception that bypassed retry logic.

On Python 3.11+, they unified the classes so the bug was invisible.

## Tests

- `test_timeout_expired_marks_task_failed` — real timeout with `sleep(5)` and `timeout=1`
- `test_futures_timeout_error_is_caught` — mocks `_execute_with_timeout` to raise `FuturesTimeoutError` directly

## Test plan

- [x] All 3 timeout tests pass
- [x] ruff lint + format pass with `.code_quality/ruff.toml`

Closes #245