### PR TITLE
⚙️ FEATURE-#259: Add --workflow flag to dotflow start

### DIFF
--- a/docs/nav/examples/cli.md
+++ b/docs/nav/examples/cli.md
@@ -8,3 +8,4 @@
 | [cli_with_mode](https://github.com/dotflow-io/examples/blob/master/cli_with_mode.py) | `dotflow start --step examples.cli_with_mode.simple_step --mode sequential` |
 | [cli_with_output_context](https://github.com/dotflow-io/examples/blob/master/cli_with_output_context.py) | `dotflow start --step examples.cli_with_output_context.simple_step --storage file` |
 | [cli_with_path](https://github.com/dotflow-io/examples/blob/master/cli_with_path.py) | `dotflow start --step examples.cli_with_path.simple_step --path .storage --storage file` |
+| [cli_with_workflow](https://github.com/dotflow-io/examples/blob/master/cli_with_workflow.py) | `dotflow start --workflow examples.cli_with_workflow.pipeline` |

--- a/docs/nav/how-to/cli/simple-start.md
+++ b/docs/nav/how-to/cli/simple-start.md
@@ -7,3 +7,7 @@ dotflow start --step docs_src.basic.simple_cli.simple_step
 ```
 
 {* ./docs_src/basic/simple_cli.py *}
+
+/// note
+`--step` runs a single `@action` function. To run a full multi-step pipeline, use [`--workflow`](with-workflow.md) instead.
+///

--- a/docs/nav/how-to/cli/with-deploy.md
+++ b/docs/nav/how-to/cli/with-deploy.md
@@ -79,11 +79,13 @@ dotflow deploy --platform github-actions --project my-pipeline
 | `--region` | Cloud region (default: us-east-1 for AWS, us-central1 for GCP, cn-hangzhou for Alibaba) |
 | `--schedule` | Cron expression for scheduled platforms (e.g. `*/5 * * * *`) |
 
-!!! note
-    Cron expressions use standard 5-field format (`min hour day month weekday`). Dotflow converts to the cloud provider format automatically (e.g. AWS EventBridge `cron()`).
+/// note
+Cron expressions use standard 5-field format (`min hour day month weekday`). Dotflow converts to the cloud provider format automatically (e.g. AWS EventBridge `cron()`).
+///
 
-!!! note
-    - AWS: `pip install dotflow[deploy-aws]`
-    - GCP: `pip install dotflow[deploy-gcp]`
-    - Alibaba: `pip install dotflow[deploy-alibaba]`
-    - GitHub: `pip install dotflow[deploy-github]`
+/// note
+- AWS: `pip install dotflow[deploy-aws]`
+- GCP: `pip install dotflow[deploy-gcp]`
+- Alibaba: `pip install dotflow[deploy-alibaba]`
+- GitHub: `pip install dotflow[deploy-github]`
+///

--- a/docs/nav/how-to/cli/with-workflow.md
+++ b/docs/nav/how-to/cli/with-workflow.md
@@ -1,0 +1,33 @@
+# With Workflow
+
+The `start` command supports two mutually exclusive entry points:
+
+| Flag | When to use |
+|------|-------------|
+| `--step` / `-s` | Run a single `@action`-decorated function |
+| `--workflow` / `-w` | Run a factory that returns a `DotFlow` instance |
+
+## Single step
+
+```bash
+dotflow start --step docs_src.cli.cli_with_workflow.step_one
+```
+
+## Full workflow factory
+
+The factory must be a plain callable (no `@action`) that returns a configured
+`DotFlow` — the CLI is responsible for calling `.start()`.
+
+```bash
+dotflow start --workflow docs_src.cli.cli_with_workflow.pipeline
+```
+
+```bash
+dotflow start --workflow docs_src.cli.cli_with_workflow.pipeline --mode parallel
+```
+
+{* ./docs_src/cli/cli_with_workflow.py *}
+
+/// note
+Passing both `--step` and `--workflow` at the same time is an error.
+///

--- a/docs/nav/how-to/index.md
+++ b/docs/nav/how-to/index.md
@@ -22,7 +22,7 @@
 
     ---
 
-    Scaffold projects and run flows from the terminal—**init**, **start**, and common flags for context, process mode, paths, and schedules.
+    Scaffold projects and run flows from the terminal—**init**, **start** (via `--step` or `--workflow`), and common flags for context, process mode, paths, and schedules.
 
     [:octicons-arrow-right-24: How-to guides](cli/init.md)
 

--- a/docs/nav/reference/exception.md
+++ b/docs/nav/reference/exception.md
@@ -13,3 +13,5 @@
 ::: dotflow.core.exception.ProblemOrdering
 
 ::: dotflow.core.exception.InvalidWorkflowFactory
+
+::: dotflow.core.exception.WorkflowFlagConflict

--- a/docs/nav/reference/exception.md
+++ b/docs/nav/reference/exception.md
@@ -11,3 +11,5 @@
 ::: dotflow.core.exception.NotCallableObject
 
 ::: dotflow.core.exception.ProblemOrdering
+
+::: dotflow.core.exception.InvalidWorkflowFactory

--- a/docs_src/cli/cli_with_workflow.py
+++ b/docs_src/cli/cli_with_workflow.py
@@ -1,0 +1,38 @@
+from os import system
+
+from dotflow import DotFlow, action
+
+
+@action
+def step_one():
+    return "step one done"
+
+
+@action
+def step_two():
+    return "step two done"
+
+
+def pipeline() -> DotFlow:
+    workflow = DotFlow()
+    workflow.task.add(step=step_one)
+    workflow.task.add(step=step_two)
+
+    return workflow
+
+
+def main():
+    system(
+        "dotflow start --step docs_src.cli.cli_with_workflow.step_one"
+    )
+    system(
+        "dotflow start --workflow docs_src.cli.cli_with_workflow.pipeline"
+    )
+    system(
+        "dotflow start --workflow docs_src.cli.cli_with_workflow.pipeline"
+        " --mode parallel"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dotflow/cli/commands/start.py
+++ b/dotflow/cli/commands/start.py
@@ -4,7 +4,7 @@ from os import system
 
 from dotflow import Config, DotFlow
 from dotflow.cli.command import Command
-from dotflow.core.exception import InvalidWorkflowFactory
+from dotflow.core.exception import InvalidWorkflowFactory, WorkflowFlagConflict
 from dotflow.core.module import Module
 from dotflow.core.types.execution import TypeExecution
 from dotflow.providers import (
@@ -13,6 +13,7 @@ from dotflow.providers import (
     StorageGCS,
     StorageS3,
 )
+from dotflow.utils.basic_functions import basic_callback
 
 
 class StartCommand(Command):
@@ -37,6 +38,14 @@ class StartCommand(Command):
         workflow.start(mode=self.params.mode)
 
     def _start_from_factory(self):
+        step_only_flags = {
+            "--callback": self.params.callback is not basic_callback,
+            "--initial-context": self.params.initial_context is not None,
+        }
+        for flag, provided in step_only_flags.items():
+            if provided:
+                raise WorkflowFlagConflict(flag=flag)
+
         factory = Module(self.params.workflow)
 
         if not callable(factory):

--- a/dotflow/cli/commands/start.py
+++ b/dotflow/cli/commands/start.py
@@ -4,6 +4,8 @@ from os import system
 
 from dotflow import Config, DotFlow
 from dotflow.cli.command import Command
+from dotflow.core.exception import InvalidWorkflowFactory
+from dotflow.core.module import Module
 from dotflow.core.types.execution import TypeExecution
 from dotflow.providers import (
     StorageDefault,
@@ -14,7 +16,17 @@ from dotflow.providers import (
 
 
 class StartCommand(Command):
+
     def setup(self):
+        if getattr(self.params, "workflow", None):
+            self._start_from_factory()
+        else:
+            self._start_from_step()
+
+        if self.params.mode == TypeExecution.BACKGROUND:
+            system("/bin/bash")
+
+    def _start_from_step(self):
         workflow = self._new_workflow()
 
         workflow.task.add(
@@ -25,8 +37,18 @@ class StartCommand(Command):
 
         workflow.start(mode=self.params.mode)
 
-        if self.params.mode == TypeExecution.BACKGROUND:
-            system("/bin/bash")
+    def _start_from_factory(self):
+        factory = Module(self.params.workflow)
+
+        if not callable(factory):
+            raise InvalidWorkflowFactory(factory=self.params.workflow)
+
+        result = factory()
+
+        if not isinstance(result, DotFlow):
+            raise InvalidWorkflowFactory(factory=self.params.workflow)
+
+        result.start(mode=self.params.mode)
 
     def _new_workflow(self):
         if not self.params.storage:

--- a/dotflow/cli/commands/start.py
+++ b/dotflow/cli/commands/start.py
@@ -16,7 +16,6 @@ from dotflow.providers import (
 
 
 class StartCommand(Command):
-
     def setup(self):
         if getattr(self.params, "workflow", None):
             self._start_from_factory()

--- a/dotflow/cli/setup.py
+++ b/dotflow/cli/setup.py
@@ -18,6 +18,7 @@ from dotflow.core.exception import (
     ImportModuleError,
     InvalidWorkflowFactory,
     MissingActionDecorator,
+    WorkflowFlagConflict,
 )
 from dotflow.core.types import TypeExecution, TypeOverlap, TypeStorage
 from dotflow.logging import logger
@@ -239,6 +240,9 @@ class Command:
             print(settings.WARNING_ALERT, err)
 
         except InvalidWorkflowFactory as err:
+            print(settings.WARNING_ALERT, err)
+
+        except WorkflowFlagConflict as err:
             print(settings.WARNING_ALERT, err)
 
         except KeyboardInterrupt:

--- a/dotflow/cli/setup.py
+++ b/dotflow/cli/setup.py
@@ -16,6 +16,7 @@ from dotflow.core.exception import (
     MESSAGE_UNKNOWN_ERROR,
     ExecutionModeNotExist,
     ImportModuleError,
+    InvalidWorkflowFactory,
     MissingActionDecorator,
 )
 from dotflow.core.types import TypeExecution, TypeOverlap, TypeStorage
@@ -56,12 +57,16 @@ class Command:
         self.cmd_init.set_defaults(exec=InitCommand)
 
     def setup_start(self):
-        self.cmd_start = self.subparsers.add_parser("start", help="Start")
-        self.cmd_start = self.cmd_start.add_argument_group(
+        cmd_start_parser = self.subparsers.add_parser("start", help="Start")
+        entry_group = cmd_start_parser.add_mutually_exclusive_group(
+            required=True
+        )
+        entry_group.add_argument("-s", "--step")
+        entry_group.add_argument("-w", "--workflow")
+
+        self.cmd_start = cmd_start_parser.add_argument_group(
             "Usage: dotflow start [OPTIONS]"
         )
-
-        self.cmd_start.add_argument("-s", "--step", required=True)
         self.cmd_start.add_argument("-c", "--callback", default=basic_callback)
         self.cmd_start.add_argument("-i", "--initial-context")
         self.cmd_start.add_argument(
@@ -88,7 +93,7 @@ class Command:
             ],
         )
 
-        self.cmd_start.set_defaults(exec=StartCommand)
+        cmd_start_parser.set_defaults(exec=StartCommand)
 
     def setup_schedule(self):
         self.cmd_schedule = self.subparsers.add_parser(
@@ -231,6 +236,9 @@ class Command:
             print(settings.WARNING_ALERT, err)
 
         except ImportModuleError as err:
+            print(settings.WARNING_ALERT, err)
+
+        except InvalidWorkflowFactory as err:
             print(settings.WARNING_ALERT, err)
 
         except KeyboardInterrupt:

--- a/dotflow/core/exception.py
+++ b/dotflow/core/exception.py
@@ -18,6 +18,9 @@ MESSAGE_MODULE_NOT_FOUND = (
 MESSAGE_INVALID_WORKFLOW_FACTORY = (
     "'{factory}' must be a callable that returns a DotFlow instance."
 )
+MESSAGE_WORKFLOW_FLAG_CONFLICT = (
+    "{flag} is only valid with --step and cannot be used with --workflow."
+)
 
 
 class MissingActionDecorator(Exception):
@@ -56,6 +59,13 @@ class InvalidWorkflowFactory(Exception):
     def __init__(self, factory: str):
         super().__init__(
             MESSAGE_INVALID_WORKFLOW_FACTORY.format(factory=factory)
+        )
+
+
+class WorkflowFlagConflict(Exception):
+    def __init__(self, flag: str):
+        super().__init__(
+            MESSAGE_WORKFLOW_FLAG_CONFLICT.format(flag=flag)
         )
 
 

--- a/dotflow/core/exception.py
+++ b/dotflow/core/exception.py
@@ -15,6 +15,9 @@ MESSAGE_PROBLEM_ORDERING = (
 MESSAGE_MODULE_NOT_FOUND = (
     "Module '{module}' not found. Please install with 'pip install {library}'"
 )
+MESSAGE_INVALID_WORKFLOW_FACTORY = (
+    "'{factory}' must be a callable that returns a DotFlow instance."
+)
 
 
 class MissingActionDecorator(Exception):
@@ -46,6 +49,13 @@ class ModuleNotFound(Exception):
     def __init__(self, module: str, library: str):
         super().__init__(
             MESSAGE_MODULE_NOT_FOUND.format(module=module, library=library)
+        )
+
+
+class InvalidWorkflowFactory(Exception):
+    def __init__(self, factory: str):
+        super().__init__(
+            MESSAGE_INVALID_WORKFLOW_FACTORY.format(factory=factory)
         )
 
 

--- a/dotflow/core/exception.py
+++ b/dotflow/core/exception.py
@@ -64,9 +64,7 @@ class InvalidWorkflowFactory(Exception):
 
 class WorkflowFlagConflict(Exception):
     def __init__(self, flag: str):
-        super().__init__(
-            MESSAGE_WORKFLOW_FLAG_CONFLICT.format(flag=flag)
-        )
+        super().__init__(MESSAGE_WORKFLOW_FLAG_CONFLICT.format(flag=flag))
 
 
 class ExecutionWithClassError(Exception):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -199,6 +199,7 @@ plugins:
         nav/learn/cli/with-mode.md: nav/how-to/cli/with-mode.md
         nav/learn/cli/with-output-context.md: nav/how-to/cli/with-output-context.md
         nav/learn/cli/with-schedule.md: nav/how-to/cli/with-schedule.md
+        nav/learn/cli/with-workflow.md: nav/how-to/cli/with-workflow.md
         nav/learn/examples.md: nav/examples/index.md
         pt/nav/learn/concept-cron-overlap.md: pt/nav/concepts/concept-cron-overlap.md
         pt/nav/learn/concept-of-context.md: pt/nav/concepts/concept-of-context.md
@@ -255,6 +256,7 @@ nav:
         - nav/how-to/cli/with-output-context.md
         - nav/how-to/cli/with-custom-path.md
         - nav/how-to/cli/with-schedule.md
+        - nav/how-to/cli/with-workflow.md
         - nav/how-to/cli/with-deploy.md
     - Integrations:
       - Overview: nav/integrations/index.md

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("cookiecutter", MagicMock())
+sys.modules.setdefault("cookiecutter.main", MagicMock())

--- a/tests/cli/test_start_command.py
+++ b/tests/cli/test_start_command.py
@@ -1,0 +1,63 @@
+"""Tests for StartCommand --workflow factory validation."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dotflow import DotFlow
+from dotflow.cli.commands.start import StartCommand
+from dotflow.core.exception import InvalidWorkflowFactory, WorkflowFlagConflict
+from dotflow.utils.basic_functions import basic_callback
+
+
+def _make_cmd(**kwargs):
+    defaults = dict(
+        step=None,
+        workflow=None,
+        callback=basic_callback,
+        initial_context=None,
+        storage=None,
+        path="/tmp",
+        mode="sequential",
+    )
+    defaults.update(kwargs)
+    cmd = StartCommand.__new__(StartCommand)
+    cmd.params = SimpleNamespace(**defaults)
+    return cmd
+
+
+class TestStartFromFactory:
+    def test_raises_when_factory_not_callable(self):
+        cmd = _make_cmd(workflow="dotflow.core.exception.MESSAGE_UNKNOWN_ERROR")
+        with pytest.raises(InvalidWorkflowFactory):
+            cmd._start_from_factory()
+
+    def test_raises_when_factory_returns_non_dotflow(self):
+        cmd = _make_cmd(workflow="dotflow.utils.basic_functions.basic_callback")
+        with pytest.raises(InvalidWorkflowFactory):
+            cmd._start_from_factory()
+
+    def test_raises_on_callback_flag_conflict(self):
+        custom_cb = MagicMock()
+        cmd = _make_cmd(workflow="dotflow.utils.basic_functions.basic_callback", callback=custom_cb)
+        with pytest.raises(WorkflowFlagConflict):
+            cmd._start_from_factory()
+
+    def test_raises_on_initial_context_flag_conflict(self):
+        cmd = _make_cmd(workflow="dotflow.utils.basic_functions.basic_callback", initial_context="abc")
+        with pytest.raises(WorkflowFlagConflict):
+            cmd._start_from_factory()
+
+    def test_valid_factory_calls_start(self):
+        mock_workflow = MagicMock()
+
+        def factory():
+            return mock_workflow
+
+        with patch("dotflow.cli.commands.start.Module", return_value=factory):
+            with patch("dotflow.cli.commands.start.isinstance", return_value=True):
+                cmd = _make_cmd(workflow="mymod.factory")
+                cmd._start_from_factory()
+
+        mock_workflow.start.assert_called_once_with(mode="sequential")

--- a/tests/cli/test_start_command.py
+++ b/tests/cli/test_start_command.py
@@ -5,22 +5,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dotflow import DotFlow
 from dotflow.cli.commands.start import StartCommand
 from dotflow.core.exception import InvalidWorkflowFactory, WorkflowFlagConflict
 from dotflow.utils.basic_functions import basic_callback
 
 
 def _make_cmd(**kwargs):
-    defaults = dict(
-        step=None,
-        workflow=None,
-        callback=basic_callback,
-        initial_context=None,
-        storage=None,
-        path="/tmp",
-        mode="sequential",
-    )
+    defaults = {
+        "step": None,
+        "workflow": None,
+        "callback": basic_callback,
+        "initial_context": None,
+        "storage": None,
+        "path": "/tmp",
+        "mode": "sequential",
+    }
     defaults.update(kwargs)
     cmd = StartCommand.__new__(StartCommand)
     cmd.params = SimpleNamespace(**defaults)
@@ -29,23 +28,33 @@ def _make_cmd(**kwargs):
 
 class TestStartFromFactory:
     def test_raises_when_factory_not_callable(self):
-        cmd = _make_cmd(workflow="dotflow.core.exception.MESSAGE_UNKNOWN_ERROR")
+        cmd = _make_cmd(
+            workflow="dotflow.core.exception.MESSAGE_UNKNOWN_ERROR"
+        )
         with pytest.raises(InvalidWorkflowFactory):
             cmd._start_from_factory()
 
     def test_raises_when_factory_returns_non_dotflow(self):
-        cmd = _make_cmd(workflow="dotflow.utils.basic_functions.basic_callback")
+        cmd = _make_cmd(
+            workflow="dotflow.utils.basic_functions.basic_callback"
+        )
         with pytest.raises(InvalidWorkflowFactory):
             cmd._start_from_factory()
 
     def test_raises_on_callback_flag_conflict(self):
         custom_cb = MagicMock()
-        cmd = _make_cmd(workflow="dotflow.utils.basic_functions.basic_callback", callback=custom_cb)
+        cmd = _make_cmd(
+            workflow="dotflow.utils.basic_functions.basic_callback",
+            callback=custom_cb,
+        )
         with pytest.raises(WorkflowFlagConflict):
             cmd._start_from_factory()
 
     def test_raises_on_initial_context_flag_conflict(self):
-        cmd = _make_cmd(workflow="dotflow.utils.basic_functions.basic_callback", initial_context="abc")
+        cmd = _make_cmd(
+            workflow="dotflow.utils.basic_functions.basic_callback",
+            initial_context="abc",
+        )
         with pytest.raises(WorkflowFlagConflict):
             cmd._start_from_factory()
 
@@ -55,9 +64,11 @@ class TestStartFromFactory:
         def factory():
             return mock_workflow
 
-        with patch("dotflow.cli.commands.start.Module", return_value=factory):
-            with patch("dotflow.cli.commands.start.isinstance", return_value=True):
-                cmd = _make_cmd(workflow="mymod.factory")
-                cmd._start_from_factory()
+        with (
+            patch("dotflow.cli.commands.start.Module", return_value=factory),
+            patch("dotflow.cli.commands.start.isinstance", return_value=True),
+        ):
+            cmd = _make_cmd(workflow="mymod.factory")
+            cmd._start_from_factory()
 
         mock_workflow.start.assert_called_once_with(mode="sequential")


### PR DESCRIPTION
Closes #259

## Description

Adds a `--workflow` / `-w` flag to `dotflow start` as a mutually exclusive alternative to `--step`, enabling users to run full multi-step pipelines from the CLI without wrapping orchestration logic inside an `@action` decorator.

### Modified files

| File | Change |
|------|--------|
| `dotflow/cli/commands/start.py` | Split `setup()` into `_start_from_step()` and `_start_from_factory()`. Factory path resolves the target via `Module(path)`, validates it is callable and returns a `DotFlow` instance, then calls `result.start(mode=...)`. Flags exclusive to `--step` (`--callback`, `--initial-context`) raise `WorkflowFlagConflict` if passed with `--workflow`. |
| `dotflow/cli/setup.py` | Made `--step` and `--workflow` a `add_mutually_exclusive_group(required=True)`. Registered exception handlers for `InvalidWorkflowFactory` and `WorkflowFlagConflict`. Fixed `set_defaults` to target the top-level parser instead of the argument group. |
| `dotflow/core/exception.py` | Added `InvalidWorkflowFactory` (non-callable or wrong return type) and `WorkflowFlagConflict` (step-only flags used with `--workflow`) with descriptive messages. |
| `tests/cli/test_start_command.py` | New test suite covering: non-callable factory, wrong return type, `--callback` flag conflict, `--initial-context` flag conflict, and happy-path factory execution. |
| `docs/nav/how-to/cli/with-workflow.md` | New how-to guide explaining `--step` vs `--workflow`, factory shape, and CLI examples. |
| `docs_src/cli/cli_with_workflow.py` | Example demonstrating both single-step and factory-based workflow invocation. |
| `docs/nav/examples/cli.md` | Added `cli_with_workflow` to the examples table. |
| `docs/nav/how-to/cli/simple-start.md` | Added note linking to `--workflow` as an alternative to `--step`. |
| `docs/nav/how-to/cli/with-deploy.md` | Modernized note block syntax from `!!!` to `///`. |
| `docs/nav/how-to/index.md` | Updated CLI section description to mention `--workflow`. |
| `docs/nav/reference/exception.md` | Added API reference for `InvalidWorkflowFactory` and `WorkflowFlagConflict`. |
| `mkdocs.yml` | Registered `with-workflow.md` in navigation and redirects. |

## Motivation and Context

Before this PR, running a multi-step workflow from the CLI required wrapping the entire orchestration inside an `@action`-decorated function — mixing step and orchestrator semantics. The CLI had no way to control execution mode, storage, or other parameters for multi-step pipelines.

The `--workflow` flag solves this by accepting a factory function (`module.attr`) that returns a configured `DotFlow` instance. The CLI is then responsible for calling `.start()`, giving it full control over execution parameters like `--mode`.

## Types of changes

- [x] New feature (change which adds functionality)
- [x] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [x] I have updated the documentation accordingly