### PR TITLE
🪲 BUG-#262: Fix entry point separator to use standard module.path:attribute format

### DIFF
--- a/docs/nav/examples/cli.md
+++ b/docs/nav/examples/cli.md
@@ -2,10 +2,10 @@
 
 | Example | Command |
 | ------- | ------- |
-| [simple_cli](https://github.com/dotflow-io/examples/blob/master/simple_cli.py) | `dotflow start --step examples.simple_cli.simple_step` |
-| [cli_with_callback](https://github.com/dotflow-io/examples/blob/master/cli_with_callback.py) | `dotflow start --step examples.cli_with_callback.simple_step --callback examples.cli_with_callback.callback` |
-| [cli_with_initial_context](https://github.com/dotflow-io/examples/blob/master/cli_with_initial_context.py) | `dotflow start --step examples.cli_with_initial_context.simple_step --initial-context abc` |
-| [cli_with_mode](https://github.com/dotflow-io/examples/blob/master/cli_with_mode.py) | `dotflow start --step examples.cli_with_mode.simple_step --mode sequential` |
-| [cli_with_output_context](https://github.com/dotflow-io/examples/blob/master/cli_with_output_context.py) | `dotflow start --step examples.cli_with_output_context.simple_step --storage file` |
-| [cli_with_path](https://github.com/dotflow-io/examples/blob/master/cli_with_path.py) | `dotflow start --step examples.cli_with_path.simple_step --path .storage --storage file` |
-| [cli_with_workflow](https://github.com/dotflow-io/examples/blob/master/cli_with_workflow.py) | `dotflow start --workflow examples.cli_with_workflow.pipeline` |
+| [simple_cli](https://github.com/dotflow-io/examples/blob/master/simple_cli.py) | `dotflow start --step examples.simple_cli:simple_step` |
+| [cli_with_callback](https://github.com/dotflow-io/examples/blob/master/cli_with_callback.py) | `dotflow start --step examples.cli_with_callback:simple_step --callback examples.cli_with_callback:callback` |
+| [cli_with_initial_context](https://github.com/dotflow-io/examples/blob/master/cli_with_initial_context.py) | `dotflow start --step examples.cli_with_initial_context:simple_step --initial-context abc` |
+| [cli_with_mode](https://github.com/dotflow-io/examples/blob/master/cli_with_mode.py) | `dotflow start --step examples.cli_with_mode:simple_step --mode sequential` |
+| [cli_with_output_context](https://github.com/dotflow-io/examples/blob/master/cli_with_output_context.py) | `dotflow start --step examples.cli_with_output_context:simple_step --storage file` |
+| [cli_with_path](https://github.com/dotflow-io/examples/blob/master/cli_with_path.py) | `dotflow start --step examples.cli_with_path:simple_step --path .storage --storage file` |
+| [cli_with_workflow](https://github.com/dotflow-io/examples/blob/master/cli_with_workflow.py) | `dotflow start --workflow examples.cli_with_workflow:pipeline` |

--- a/docs/nav/how-to/cli/simple-start.md
+++ b/docs/nav/how-to/cli/simple-start.md
@@ -3,7 +3,7 @@
 Run a single step from the command line.
 
 ```bash
-dotflow start --step docs_src.basic.simple_cli.simple_step
+dotflow start --step docs_src.basic.simple_cli:simple_step
 ```
 
 {* ./docs_src/basic/simple_cli.py *}

--- a/docs/nav/how-to/cli/with-callback.md
+++ b/docs/nav/how-to/cli/with-callback.md
@@ -3,7 +3,7 @@
 Attach a callback function that runs after the step completes.
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_callback.simple_step --callback docs_src.cli.cli_with_callback.callback
+dotflow start --step docs_src.cli.cli_with_callback:simple_step --callback docs_src.cli.cli_with_callback:callback
 ```
 
 {* ./docs_src/cli/cli_with_callback.py *}

--- a/docs/nav/how-to/cli/with-custom-path.md
+++ b/docs/nav/how-to/cli/with-custom-path.md
@@ -3,11 +3,11 @@
 Set a custom output path for file storage.
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_path.simple_step --path .storage --storage file
+dotflow start --step docs_src.cli.cli_with_path:simple_step --path .storage --storage file
 ```
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_path.simple_step --path . --storage file
+dotflow start --step docs_src.cli.cli_with_path:simple_step --path . --storage file
 ```
 
 {* ./docs_src/cli/cli_with_path.py *}

--- a/docs/nav/how-to/cli/with-initial-context.md
+++ b/docs/nav/how-to/cli/with-initial-context.md
@@ -3,7 +3,7 @@
 Pass initial data to a step via the `--initial-context` flag.
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_initial_context.simple_step --initial-context abc
+dotflow start --step docs_src.cli.cli_with_initial_context:simple_step --initial-context abc
 ```
 
 {* ./docs_src/cli/cli_with_initial_context.py *}

--- a/docs/nav/how-to/cli/with-mode.md
+++ b/docs/nav/how-to/cli/with-mode.md
@@ -3,15 +3,15 @@
 Choose the execution mode: `sequential`, `background`, or `parallel`.
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_mode.simple_step --mode sequential
+dotflow start --step docs_src.cli.cli_with_mode:simple_step --mode sequential
 ```
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_mode.simple_step --mode background
+dotflow start --step docs_src.cli.cli_with_mode:simple_step --mode background
 ```
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_mode.simple_step --mode parallel
+dotflow start --step docs_src.cli.cli_with_mode:simple_step --mode parallel
 ```
 
 {* ./docs_src/cli/cli_with_mode.py *}

--- a/docs/nav/how-to/cli/with-output-context.md
+++ b/docs/nav/how-to/cli/with-output-context.md
@@ -3,7 +3,7 @@
 Persist task output to disk using file storage.
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_output_context.simple_step --storage file
+dotflow start --step docs_src.cli.cli_with_output_context:simple_step --storage file
 ```
 
 {* ./docs_src/cli/cli_with_output_context.py *}

--- a/docs/nav/how-to/cli/with-workflow.md
+++ b/docs/nav/how-to/cli/with-workflow.md
@@ -10,7 +10,7 @@ The `start` command supports two mutually exclusive entry points:
 ## Single step
 
 ```bash
-dotflow start --step docs_src.cli.cli_with_workflow.step_one
+dotflow start --step docs_src.cli.cli_with_workflow:step_one
 ```
 
 ## Full workflow factory
@@ -19,11 +19,11 @@ The factory must be a plain callable (no `@action`) that returns a configured
 `DotFlow` — the CLI is responsible for calling `.start()`.
 
 ```bash
-dotflow start --workflow docs_src.cli.cli_with_workflow.pipeline
+dotflow start --workflow docs_src.cli.cli_with_workflow:pipeline
 ```
 
 ```bash
-dotflow start --workflow docs_src.cli.cli_with_workflow.pipeline --mode parallel
+dotflow start --workflow docs_src.cli.cli_with_workflow:pipeline --mode parallel
 ```
 
 {* ./docs_src/cli/cli_with_workflow.py *}

--- a/docs_src/basic/simple_cli.py
+++ b/docs_src/basic/simple_cli.py
@@ -9,7 +9,7 @@ def simple_step():
 
 
 def main():
-    system("dotflow start --step docs_src.basic.simple_cli.simple_step")
+    system("dotflow start --step docs_src.basic.simple_cli:simple_step")
 
 
 if __name__ == "__main__":

--- a/docs_src/cli/cli_with_callback.py
+++ b/docs_src/cli/cli_with_callback.py
@@ -14,8 +14,8 @@ def simple_step():
 
 def main():
     system(
-        "dotflow start --step docs_src.cli.cli_with_callback.simple_step "
-        "--callback docs_src.cli.cli_with_callback.callback"
+        "dotflow start --step docs_src.cli.cli_with_callback:simple_step "
+        "--callback docs_src.cli.cli_with_callback:callback"
     )
 
 

--- a/docs_src/cli/cli_with_initial_context.py
+++ b/docs_src/cli/cli_with_initial_context.py
@@ -12,7 +12,7 @@ def simple_step(initial_context):
 
 def main():
     system(
-        "dotflow start --step docs_src.cli.cli_with_initial_context.simple_step "
+        "dotflow start --step docs_src.cli.cli_with_initial_context:simple_step "
         "--initial-context abc"
     )
 

--- a/docs_src/cli/cli_with_mode.py
+++ b/docs_src/cli/cli_with_mode.py
@@ -10,14 +10,14 @@ def simple_step():
 
 def main():
     system(
-        "dotflow start --step docs_src.cli.cli_with_mode.simple_step --mode sequential"
+        "dotflow start --step docs_src.cli.cli_with_mode:simple_step --mode sequential"
     )
     system(
-        "dotflow start --step docs_src.cli.cli_with_mode.simple_step --mode background"
+        "dotflow start --step docs_src.cli.cli_with_mode:simple_step --mode background"
     )
 
     system(
-        "dotflow start --step docs_src.cli.cli_with_mode.simple_step --mode parallel"
+        "dotflow start --step docs_src.cli.cli_with_mode:simple_step --mode parallel"
     )
 
 

--- a/docs_src/cli/cli_with_output_context.py
+++ b/docs_src/cli/cli_with_output_context.py
@@ -10,7 +10,7 @@ def simple_step():
 
 def main():
     system(
-        "dotflow start --step docs_src.cli.cli_with_output_context.simple_step "
+        "dotflow start --step docs_src.cli.cli_with_output_context:simple_step "
         "--storage file"
     )
 

--- a/docs_src/cli/cli_with_path.py
+++ b/docs_src/cli/cli_with_path.py
@@ -10,12 +10,12 @@ def simple_step():
 
 def main():
     system(
-        "dotflow start --step docs_src.cli.cli_with_path.simple_step "
+        "dotflow start --step docs_src.cli.cli_with_path:simple_step "
         "--path .storage --storage file"
     )
 
     system(
-        "dotflow start --step docs_src.cli.cli_with_path.simple_step "
+        "dotflow start --step docs_src.cli.cli_with_path:simple_step "
         "--path . --storage file"
     )
 

--- a/docs_src/cli/cli_with_workflow.py
+++ b/docs_src/cli/cli_with_workflow.py
@@ -23,13 +23,13 @@ def pipeline() -> DotFlow:
 
 def main():
     system(
-        "dotflow start --step docs_src.cli.cli_with_workflow.step_one"
+        "dotflow start --step docs_src.cli.cli_with_workflow:step_one"
     )
     system(
-        "dotflow start --workflow docs_src.cli.cli_with_workflow.pipeline"
+        "dotflow start --workflow docs_src.cli.cli_with_workflow:pipeline"
     )
     system(
-        "dotflow start --workflow docs_src.cli.cli_with_workflow.pipeline"
+        "dotflow start --workflow docs_src.cli.cli_with_workflow:pipeline"
         " --mode parallel"
     )
 

--- a/dotflow/core/module.py
+++ b/dotflow/core/module.py
@@ -14,7 +14,7 @@ class Module:
 
     @classmethod
     def import_module(cls, value: str):
-        module_path, _, attr_name = value.rpartition(".")
+        module_path, _, attr_name = value.rpartition(":")
 
         if not module_path:
             raise ImportModuleError(module=value)

--- a/dotflow/core/module.py
+++ b/dotflow/core/module.py
@@ -14,7 +14,8 @@ class Module:
 
     @classmethod
     def import_module(cls, value: str):
-        module_path, _, attr_name = value.rpartition(":")
+        separator = ":" if ":" in value else "."
+        module_path, _, attr_name = value.rpartition(separator)
 
         if not module_path:
             raise ImportModuleError(module=value)

--- a/tests/cli/test_start_command.py
+++ b/tests/cli/test_start_command.py
@@ -29,14 +29,14 @@ def _make_cmd(**kwargs):
 class TestStartFromFactory:
     def test_raises_when_factory_not_callable(self):
         cmd = _make_cmd(
-            workflow="dotflow.core.exception.MESSAGE_UNKNOWN_ERROR"
+            workflow="dotflow.core.exception:MESSAGE_UNKNOWN_ERROR"
         )
         with pytest.raises(InvalidWorkflowFactory):
             cmd._start_from_factory()
 
     def test_raises_when_factory_returns_non_dotflow(self):
         cmd = _make_cmd(
-            workflow="dotflow.utils.basic_functions.basic_callback"
+            workflow="dotflow.utils.basic_functions:basic_callback"
         )
         with pytest.raises(InvalidWorkflowFactory):
             cmd._start_from_factory()
@@ -44,7 +44,7 @@ class TestStartFromFactory:
     def test_raises_on_callback_flag_conflict(self):
         custom_cb = MagicMock()
         cmd = _make_cmd(
-            workflow="dotflow.utils.basic_functions.basic_callback",
+            workflow="dotflow.utils.basic_functions:basic_callback",
             callback=custom_cb,
         )
         with pytest.raises(WorkflowFlagConflict):
@@ -52,7 +52,7 @@ class TestStartFromFactory:
 
     def test_raises_on_initial_context_flag_conflict(self):
         cmd = _make_cmd(
-            workflow="dotflow.utils.basic_functions.basic_callback",
+            workflow="dotflow.utils.basic_functions:basic_callback",
             initial_context="abc",
         )
         with pytest.raises(WorkflowFlagConflict):
@@ -68,7 +68,7 @@ class TestStartFromFactory:
             patch("dotflow.cli.commands.start.Module", return_value=factory),
             patch("dotflow.cli.commands.start.isinstance", return_value=True),
         ):
-            cmd = _make_cmd(workflow="mymod.factory")
+            cmd = _make_cmd(workflow="mymod:factory")
             cmd._start_from_factory()
 
         mock_workflow.start.assert_called_once_with(mode="sequential")

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -148,6 +148,14 @@ class TestTaskSetter(unittest.TestCase):
         with self.assertRaises(ImportModuleError):
             Task(task_id=0, step=input_value, callback=simple_callback)
 
+    def test_set_step_with_dot_format_fallback_success(self):
+        input_value = "tests.mocks.step_function.action_step"
+        expected_value = Action
+
+        task = Task(task_id=0, step=input_value, callback=simple_callback)
+
+        self.assertIsInstance(task.step, expected_value)
+
     def test_set_step_with_function_success(self):
         input_value = action_step
         expected_value = Action

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -135,7 +135,7 @@ class TestTaskSetter(unittest.TestCase):
         self.content = {"foo": "bar"}
 
     def test_set_step_with_path_module_success(self):
-        input_value = "tests.mocks.step_function.action_step"
+        input_value = "tests.mocks.step_function:action_step"
         expected_value = Action
 
         task = Task(task_id=0, step=input_value, callback=simple_callback)
@@ -143,7 +143,7 @@ class TestTaskSetter(unittest.TestCase):
         self.assertIsInstance(task.step, expected_value)
 
     def test_set_step_with_path_module_fail(self):
-        input_value = "tests.mocks.step_function.XPTO"
+        input_value = "tests.mocks.step_function:XPTO"
 
         with self.assertRaises(ImportModuleError):
             Task(task_id=0, step=input_value, callback=simple_callback)
@@ -163,7 +163,7 @@ class TestTaskSetter(unittest.TestCase):
             Task(task_id=0, step=input_value, callback=simple_callback)
 
     def test_set_callback_with_path_module_success(self):
-        input_value = "tests.mocks.step_function.action_step"
+        input_value = "tests.mocks.step_function:action_step"
         expected_value = Action
 
         task = Task(task_id=0, step=action_step, callback=input_value)
@@ -171,13 +171,13 @@ class TestTaskSetter(unittest.TestCase):
         self.assertIsInstance(task.step, expected_value)
 
     def test_set_callback_with_path_module_fail(self):
-        input_value = "tests.mocks.step_function.XPTO"
+        input_value = "tests.mocks.step_function:XPTO"
 
         with self.assertRaises(ImportModuleError):
             Task(task_id=0, step=action_step, callback=input_value)
 
     def test_set_callback_with_path_module_not_callable_fail(self):
-        input_value = "tests.mocks.constants.NOT_CALLABLE"
+        input_value = "tests.mocks.constants:NOT_CALLABLE"
 
         with self.assertRaises(NotCallableObject):
             Task(task_id=0, step=action_step, callback=input_value)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -117,11 +117,11 @@ def main():
     workflow = DotFlow()
     workflow.task.add(
         [
-            "tests.test_flow.StepX",
-            "tests.test_flow.StepY",
-            "tests.test_flow.extract_task_x",
-            "tests.test_flow.transform_task_x",
-            "tests.test_flow.load_task_x",
+            "tests.test_flow:StepX",
+            "tests.test_flow:StepY",
+            "tests.test_flow:extract_task_x",
+            "tests.test_flow:transform_task_x",
+            "tests.test_flow:load_task_x",
             simple_step,
         ],
         initial_context={"foo": "bar"},


### PR DESCRIPTION
## Description
Changes the entry point separator in  from  to  to align with Python's standard packaging convention for module entry points. This change affects how the CLI parses and executes module attributes.

**Modified files:**
-  - Updated partition logic
- Test files - Updated to use new  format

## Motivation and Context
This change standardizes dotflow's entry point format to match Python's industry-standard module entry point specification (PEP 440 and setuptools conventions). The colon separator () is the standard delimiter used by Python packaging tools, making dotflow more aligned with ecosystem conventions.

Closes #262

## Types of changes
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Breaking change

## Breaking Change Notice
**CLI usage changes:**
- Old format: `dotflow start --step my_module.my_step`
- New format: `dotflow start --step my_module:my_step`

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly (open issue)
