### PR TITLE
🪲 BUG-#264: Honour WORKFLOW_ID env var in DotFlow constructor

### DIFF
--- a/dotflow/core/dotflow.py
+++ b/dotflow/core/dotflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from functools import partial
 from uuid import uuid4
 
@@ -48,6 +49,7 @@ class DotFlow:
         config: Config | None = None,
         workflow_id: str | None = None,
     ) -> None:
+        workflow_id = workflow_id or os.getenv("WORKFLOW_ID")
         self._externally_provided_id = workflow_id is not None
         self.workflow_id = workflow_id or uuid4()
         self._config = config if config else Config()


### PR DESCRIPTION
## Description

- `dotflow/core/dotflow.py` — `DotFlow.__init__` now falls back to `os.getenv("WORKFLOW_ID")` when no explicit `workflow_id` is passed, and treats the env-provided id as externally provided (skipping `server.create_workflow`).

## Motivation and Context

External integrations that expose `WORKFLOW_ID` via environment expected the runner to adopt that id. The constructor ignored the env var and always generated a fresh UUID, causing scoped-token callbacks (`SERVER_USER_TOKEN`) to fail with 401/403.

Closes #264

## Types of changes

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly