### PR TITLE
⚙️ FEATURE-#267: Add --resume flag to dotflow start CLI

### DIFF
--- a/dotflow/cli/commands/start.py
+++ b/dotflow/cli/commands/start.py
@@ -17,7 +17,6 @@ from dotflow.utils.basic_functions import basic_callback
 
 
 class StartCommand(Command):
-
     def setup(self):
         if getattr(self.params, "workflow", None):
             self._start_from_factory()

--- a/dotflow/cli/commands/start.py
+++ b/dotflow/cli/commands/start.py
@@ -17,6 +17,7 @@ from dotflow.utils.basic_functions import basic_callback
 
 
 class StartCommand(Command):
+
     def setup(self):
         if getattr(self.params, "workflow", None):
             self._start_from_factory()
@@ -35,7 +36,7 @@ class StartCommand(Command):
             initial_context=self.params.initial_context,
         )
 
-        workflow.start(mode=self.params.mode)
+        workflow.start(mode=self.params.mode, resume=self.params.resume)
 
     def _start_from_factory(self):
         step_only_flags = {
@@ -56,7 +57,7 @@ class StartCommand(Command):
         if not isinstance(result, DotFlow):
             raise InvalidWorkflowFactory(factory=self.params.workflow)
 
-        result.start(mode=self.params.mode)
+        result.start(mode=self.params.mode, resume=self.params.resume)
 
     def _new_workflow(self):
         storage = self._build_storage()

--- a/dotflow/cli/setup.py
+++ b/dotflow/cli/setup.py
@@ -93,6 +93,12 @@ class Command:
                 TypeExecution.PARALLEL,
             ],
         )
+        self.cmd_start.add_argument(
+            "--resume",
+            action="store_true",
+            default=False,
+            help="Enable checkpoint-based resume",
+        )
 
         cmd_start_parser.set_defaults(exec=StartCommand)
 

--- a/tests/cli/test_start_command.py
+++ b/tests/cli/test_start_command.py
@@ -19,6 +19,7 @@ def _make_cmd(**kwargs):
         "storage": None,
         "path": "/tmp",
         "mode": "sequential",
+        "resume": False,
     }
     defaults.update(kwargs)
     cmd = StartCommand.__new__(StartCommand)
@@ -90,4 +91,49 @@ class TestStartFromFactory:
             cmd = _make_cmd(workflow="mymod:factory")
             cmd._start_from_factory()
 
-        mock_workflow.start.assert_called_once_with(mode="sequential")
+        mock_workflow.start.assert_called_once_with(
+            mode="sequential", resume=False
+        )
+
+    def test_valid_factory_forwards_resume_flag(self):
+        mock_workflow = MagicMock()
+
+        def factory():
+            return mock_workflow
+
+        with (
+            patch("dotflow.cli.commands.start.Module", return_value=factory),
+            patch("dotflow.cli.commands.start.isinstance", return_value=True),
+        ):
+            cmd = _make_cmd(workflow="mymod:factory", resume=True)
+            cmd._start_from_factory()
+
+        mock_workflow.start.assert_called_once_with(
+            mode="sequential", resume=True
+        )
+
+
+class TestStartFromStep:
+    @patch("dotflow.cli.commands.start.DotFlow")
+    def test_step_forwards_resume_flag(self, mock_dotflow):
+        mock_workflow = MagicMock()
+        mock_dotflow.return_value = mock_workflow
+
+        cmd = _make_cmd(step="mymod:my_step", resume=True)
+        cmd._start_from_step()
+
+        mock_workflow.start.assert_called_once_with(
+            mode="sequential", resume=True
+        )
+
+    @patch("dotflow.cli.commands.start.DotFlow")
+    def test_step_default_resume_is_false(self, mock_dotflow):
+        mock_workflow = MagicMock()
+        mock_dotflow.return_value = mock_workflow
+
+        cmd = _make_cmd(step="mymod:my_step")
+        cmd._start_from_step()
+
+        mock_workflow.start.assert_called_once_with(
+            mode="sequential", resume=False
+        )


### PR DESCRIPTION
## Summary
- Added `--resume` to `dotflow start` CLI (mirrors `dotflow schedule --resume`).
- `StartCommand._start_from_factory` and `_start_from_step` now forward `resume=self.params.resume` to `workflow.start()`.
- Unblocks checkpoint recovery for cloud deployments that launch via `dotflow start --workflow <module>:main` (container-style templates in dotflow-io/templates).

## Test plan
- [x] `pytest tests/cli/test_start_command.py` (10/10 passing — includes new cases for factory + step with resume flag on and off)
- [x] `ruff check dotflow/cli/ tests/cli/`

Closes #267