### PR TITLE
⚙️ FEATURE-#269: Managed DotFlow with name, idempotent start, and CLI cleanup

### DIFF
--- a/docs/nav/how-to/cli/login.md
+++ b/docs/nav/how-to/cli/login.md
@@ -1,0 +1,9 @@
+# Login
+
+Authenticate the CLI against Dotflow Cloud.
+
+```bash
+dotflow login
+```
+
+The command prints a short code, opens your browser, and waits for you to approve. On success, the CLI stores your credentials locally so you don't need to log in again.

--- a/docs/nav/how-to/cli/logout.md
+++ b/docs/nav/how-to/cli/logout.md
@@ -1,0 +1,9 @@
+# Logout
+
+Clear saved CLI credentials.
+
+```bash
+dotflow logout
+```
+
+Removes the locally stored credentials. If you weren't logged in, the command is a no-op.

--- a/docs/nav/tutorial/server-default.md
+++ b/docs/nav/tutorial/server-default.md
@@ -1,26 +1,42 @@
 # Server Default
 
-`ServerDefault` is the built-in Server provider. It auto-detects managed mode from environment variables — when `SERVER_BASE_URL` and `SERVER_USER_TOKEN` are present, it sends execution data to the remote API. Without them, all methods are no-ops.
+`ServerDefault` is the built-in Server provider. It auto-detects managed mode from the CLI config file or environment variables — when a `base_url` and `token` are available, it sends execution data to the remote API. Without them, all methods are no-ops.
 
 ## Managed mode (auto-detected)
 
-Set the environment variables before running your workflow:
+There are two ways to feed the provider.
+
+### 1. `dotflow login` (recommended)
+
+Run the device-authorization flow once and the CLI stores `base_url` + `token` in `~/.dotflow/config.json`:
+
+```bash
+dotflow login
+```
+
+Any subsequent `DotFlow()` instance picks those up automatically — no env vars, no code changes:
+
+```python
+from dotflow import DotFlow
+
+
+def main() -> DotFlow:
+    workflow = DotFlow()
+    workflow.task.add(step=my_step)
+
+    return workflow
+```
+
+### 2. Environment variables (CI/CD)
+
+For non-interactive environments, export the variables directly:
 
 ```bash
 export SERVER_BASE_URL="https://api.example.com/v1"
 export SERVER_USER_TOKEN="your-token"
 ```
 
-Any `DotFlow()` instance picks them up automatically — no code changes required:
-
-```python
-from dotflow import DotFlow
-
-def main() -> DotFlow:
-    workflow = DotFlow()
-    workflow.task.add(step=my_step)
-    return workflow
-```
+Env vars take precedence over the config file.
 
 ## Lifecycle hooks
 
@@ -33,6 +49,8 @@ The server provider is called automatically at these points:
 | Workflow completes | `update_workflow()` |
 | `task.add()` | `create_task()` |
 | Task finishes | `update_task()` |
+
+Requests hit `{base_url}/cli/workflows/*` with `Authorization: Bearer <token>`.
 
 ## Custom implementation
 

--- a/docs_src/name/workflow_with_name.py
+++ b/docs_src/name/workflow_with_name.py
@@ -1,0 +1,25 @@
+"""Workflow with a custom name.
+
+``DotFlow`` accepts an optional ``name`` kwarg that is sent to the managed
+server when the workflow is registered. When omitted, the name defaults to
+the machine hostname — useful to distinguish runs from different hosts in
+the dashboard.
+"""
+
+from dotflow import DotFlow, action
+
+
+@action
+def step_one():
+    return "done"
+
+
+def pipeline() -> DotFlow:
+    workflow = DotFlow(name="etl-nightly")
+    workflow.task.add(step=step_one)
+
+    return workflow
+
+
+if __name__ == "__main__":
+    pipeline().start()

--- a/dotflow/cli/commands/login.py
+++ b/dotflow/cli/commands/login.py
@@ -23,13 +23,7 @@ MAX_POLL_INTERVAL = 60
 
 class LoginCommand(Command):
     def setup(self):
-        token = getattr(self.params, "token", None)
         base_url = self._resolve_base_url()
-
-        if token:
-            save_cloud_config(token=token, base_url=base_url)
-            print(settings.INFO_ALERT, "Token saved.")
-            return
 
         handshake = self._start_device(base_url)
         if handshake is None:
@@ -49,10 +43,8 @@ class LoginCommand(Command):
         print(settings.INFO_ALERT, "Authenticated.")
 
     def _resolve_base_url(self) -> str:
-        """Flag or env var wins over the default."""
-        explicit = getattr(self.params, "base_url", None) or os.environ.get(
-            "SERVER_BASE_URL"
-        )
+        """``SERVER_BASE_URL`` env var wins over the default."""
+        explicit = os.environ.get("SERVER_BASE_URL")
         return explicit.rstrip("/") if explicit else DEFAULT_BASE_URL
 
     def _start_device(self, base_url: str) -> dict | None:

--- a/dotflow/cli/commands/start.py
+++ b/dotflow/cli/commands/start.py
@@ -51,12 +51,12 @@ class StartCommand(Command):
         if not callable(factory):
             raise InvalidWorkflowFactory(factory=self.params.workflow)
 
-        result = factory()
+        workflow = factory()
 
-        if not isinstance(result, DotFlow):
+        if not isinstance(workflow, DotFlow):
             raise InvalidWorkflowFactory(factory=self.params.workflow)
 
-        result.start(mode=self.params.mode, resume=self.params.resume)
+        workflow.start(mode=self.params.mode, resume=self.params.resume)
 
     def _new_workflow(self):
         storage = self._build_storage()

--- a/dotflow/cli/setup.py
+++ b/dotflow/cli/setup.py
@@ -56,17 +56,6 @@ class Command:
         cmd = self.subparsers.add_parser(
             "login", help="Authenticate the CLI via browser"
         )
-        cmd_group = cmd.add_argument_group("Usage: dotflow login [OPTIONS]")
-        cmd_group.add_argument(
-            "--base-url",
-            default=None,
-            help="Override the Dotflow Cloud API base URL",
-        )
-        cmd_group.add_argument(
-            "--token",
-            default=None,
-            help="Skip the browser flow and save a pre-obtained API token",
-        )
         cmd.set_defaults(exec=LoginCommand)
 
     def setup_logout(self):

--- a/dotflow/core/dotflow.py
+++ b/dotflow/core/dotflow.py
@@ -9,6 +9,8 @@ from uuid import uuid4
 from dotflow.core.config import Config
 from dotflow.core.task import TaskBuilder
 from dotflow.core.workflow import Manager
+from dotflow.logging import logger
+from dotflow.utils import hostname
 
 
 class DotFlow:
@@ -34,8 +36,15 @@ class DotFlow:
         workflow_id (Optional[str]): Fixed workflow identifier for checkpoint
             resume. If not provided, a random UUID is generated.
 
+        name (Optional[str]): Human-readable label sent to the managed
+            server on registration. Defaults to the machine hostname so
+            runs from different hosts stay distinguishable in the
+            dashboard.
+
     Attributes:
         workflow_id (UUID):
+
+        name (str):
 
         task (List[Task]):
 
@@ -48,30 +57,47 @@ class DotFlow:
         self,
         config: Config | None = None,
         workflow_id: str | None = None,
+        name: str | None = None,
     ) -> None:
         workflow_id = workflow_id or os.getenv("WORKFLOW_ID")
         self._externally_provided_id = workflow_id is not None
         self.workflow_id = workflow_id or uuid4()
+        self.name = name or hostname()
         self._config = config if config else Config()
-
-        if not self._externally_provided_id:
-            self._config.server.create_workflow(workflow=self.workflow_id)
+        self._manager: Manager | None = None
+        self._last_run_signature: tuple = ()
 
         self.task = TaskBuilder(
             config=self._config,
             workflow_id=self.workflow_id,
+            workflow_name=self.name,
         )
 
-        self.start = partial(
-            Manager,
-            tasks=self.task.queue,
-            workflow_id=self.workflow_id,
-            config=self._config,
-        )
+        if not self._externally_provided_id:
+            self._config.server.create_workflow(workflow=self)
 
         self.schedule = partial(
             self._config.scheduler.start, workflow=self.start
         )
+
+    def start(self, **kwargs) -> Manager:
+        """Run the workflow once; duplicate calls return the original Manager."""
+        signature = tuple(task.task_id for task in self.task.queue)
+        if self._manager is not None and signature == self._last_run_signature:
+            logger.warning(
+                "DotFlow.start() already ran for %s; ignoring duplicate call",
+                self.workflow_id,
+            )
+            return self._manager
+
+        self._last_run_signature = signature
+        self._manager = Manager(
+            tasks=self.task.queue,
+            workflow_id=self.workflow_id,
+            config=self._config,
+            **kwargs,
+        )
+        return self._manager
 
     def result_task(self):
         """

--- a/dotflow/core/serializers/task.py
+++ b/dotflow/core/serializers/task.py
@@ -1,5 +1,7 @@
 """Task serializer module"""
 
+# mypy: disable-error-code="misc"
+
 from __future__ import annotations
 
 import json
@@ -48,6 +50,11 @@ class SerializerTask(BaseModel):
         default={"message": "Context size exceeded"},
         exclude=True,
     )
+
+    @computed_field
+    @property
+    def id(self) -> Optional[str]:
+        return self.task_id
 
     @computed_field
     @property

--- a/dotflow/core/serializers/workflow.py
+++ b/dotflow/core/serializers/workflow.py
@@ -1,8 +1,10 @@
 """Workflow serializer module"""
 
+# mypy: disable-error-code="misc"
+
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from dotflow.core.serializers.task import SerializerTask
 
@@ -11,4 +13,15 @@ class SerializerWorkflow(BaseModel):
     model_config = ConfigDict(title="workflow")
 
     workflow_id: UUID = Field(default=None)
+    workflow_name: str | None = Field(default=None)
     tasks: list[SerializerTask] = Field(default=[])
+
+    @computed_field
+    @property
+    def id(self) -> UUID | None:
+        return self.workflow_id
+
+    @computed_field
+    @property
+    def name(self) -> str | None:
+        return self.workflow_name

--- a/dotflow/core/task.py
+++ b/dotflow/core/task.py
@@ -310,9 +310,11 @@ class TaskBuilder:
         self,
         config: Config,
         workflow_id: UUID = None,
+        workflow_name: str | None = None,
     ) -> None:
         self.queue: list[Callable] = []
         self.workflow_id = workflow_id
+        self.workflow_name = workflow_name
         self.config = config
 
     def add(
@@ -381,6 +383,7 @@ class TaskBuilder:
     def schema(self) -> SerializerWorkflow:
         return SerializerWorkflow(
             workflow_id=self.workflow_id,
+            workflow_name=self.workflow_name,
             tasks=[item.schema() for item in self.queue],
         )
 

--- a/dotflow/providers/server_default.py
+++ b/dotflow/providers/server_default.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from functools import wraps
 from typing import Any
 
@@ -10,6 +9,7 @@ from requests import patch, post
 from requests.exceptions import RequestException
 
 from dotflow.abc.server import Server
+from dotflow.core.config_file import resolve
 from dotflow.logging import logger
 
 
@@ -35,8 +35,8 @@ class ServerDefault(Server):
     ENDPOINT_TASK = "/cli/workflows/{workflow_id}/tasks/{task_id}"
 
     def __init__(self) -> None:
-        base_url = os.environ.get("SERVER_BASE_URL") or None
-        user_token = os.environ.get("SERVER_USER_TOKEN") or None
+        base_url = resolve(key="base_url", env_var="SERVER_BASE_URL")
+        user_token = resolve(key="token", env_var="SERVER_USER_TOKEN")
         self._managed = bool(base_url and user_token)
 
         self._base_url = base_url.rstrip("/") if base_url else None
@@ -75,7 +75,7 @@ class ServerDefault(Server):
     def create_workflow(self, workflow: Any) -> None:
         self._post(
             self._base_url + self.ENDPOINT_WORKFLOWS,
-            json={"id": str(workflow)},
+            json=workflow.result(),
         )
 
     @managed
@@ -88,22 +88,19 @@ class ServerDefault(Server):
 
     @managed
     def create_task(self, task: Any) -> None:
-        data = task.result(max=self.MAX_RESULT_SIZE)
-        data["id"] = data.pop("task_id", task.task_id)
         self._post(
             self._base_url
             + self.ENDPOINT_TASKS.format(workflow_id=task.workflow_id),
-            json=data,
+            json=task.result(max=self.MAX_RESULT_SIZE),
         )
 
     @managed
     def update_task(self, task: Any) -> None:
-        data = task.result(max=self.MAX_RESULT_SIZE)
         self._patch(
             self._base_url
             + self.ENDPOINT_TASK.format(
                 workflow_id=task.workflow_id,
                 task_id=task.task_id,
             ),
-            json=data,
+            json=task.result(max=self.MAX_RESULT_SIZE),
         )

--- a/dotflow/utils/__init__.py
+++ b/dotflow/utils/__init__.py
@@ -2,13 +2,14 @@
 
 from dotflow.utils.basic_functions import basic_callback, basic_function
 from dotflow.utils.error_handler import message_error, traceback_error
-from dotflow.utils.tools import read_file, write_file
+from dotflow.utils.tools import hostname, read_file, write_file
 
 __all__ = [
     "traceback_error",
     "message_error",
     "basic_function",
     "basic_callback",
+    "hostname",
     "write_file",
     "read_file",
 ]

--- a/dotflow/utils/tools.py
+++ b/dotflow/utils/tools.py
@@ -1,8 +1,17 @@
 """Tools"""
 
+import socket
 from json import JSONDecodeError, dumps, loads
 from pathlib import Path
 from typing import Any
+
+
+def hostname() -> str:
+    """Return the local hostname, with a ``local`` fallback."""
+    try:
+        return socket.gethostname() or "local"
+    except OSError:
+        return "local"
 
 
 def write_file(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,6 +249,8 @@ nav:
         #   - nav/tutorial/output-task.md
       - Dotflow CLI:
         - nav/how-to/cli/init.md
+        - nav/how-to/cli/login.md
+        - nav/how-to/cli/logout.md
         - nav/how-to/cli/simple-start.md
         - nav/how-to/cli/with-initial-context.md
         - nav/how-to/cli/with-callback.md

--- a/tests/cli/test_login_command.py
+++ b/tests/cli/test_login_command.py
@@ -10,58 +10,20 @@ from dotflow.cli.commands.login import LoginCommand
 from dotflow.cli.commands.logout import LogoutCommand
 
 
-def _params(**kwargs) -> SimpleNamespace:
-    defaults = {"base_url": None, "token": None}
-    defaults.update(kwargs)
-    return SimpleNamespace(**defaults)
-
-
-def _make_cmd(cls, params: SimpleNamespace):
+def _make_cmd(cls):
     cmd = cls.__new__(cls)
-    cmd.params = params
+    cmd.params = SimpleNamespace()
     return cmd
 
 
 @pytest.fixture
 def tmp_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("SERVER_BASE_URL", raising=False)
     yield tmp_path
 
 
-class TestLoginWithExplicitToken:
-    def test_saves_token_without_network_calls(self, tmp_home):
-        cmd = _make_cmd(
-            LoginCommand,
-            _params(token="dtf_sk_direct", base_url="https://api.local"),
-        )
-        with (
-            patch("dotflow.cli.commands.login.post") as mock_post,
-            patch(
-                "dotflow.cli.commands.login.webbrowser.open"
-            ) as mock_browser,
-        ):
-            cmd.setup()
-            mock_post.assert_not_called()
-            mock_browser.assert_not_called()
-
-        config = tmp_home / ".dotflow" / "config.json"
-        assert config.exists()
-        content = config.read_text()
-        assert '"token": "dtf_sk_direct"' in content
-        assert '"base_url": "https://api.local"' in content
-
-
 class TestLoginDeviceFlow:
-    def _responses(self, *items):
-        for item in items:
-            r = MagicMock()
-            r.status_code = item[0]
-            if len(item) > 1:
-                r.json.return_value = item[1]
-            else:
-                r.json.return_value = {}
-            yield r
-
     def test_persists_token_on_successful_poll(self, tmp_home):
         handshake = MagicMock()
         handshake.status_code = 201
@@ -82,10 +44,7 @@ class TestLoginDeviceFlow:
         ok.status_code = 200
         ok.json.return_value = {"api_token": "dtf_sk_from_browser"}
 
-        cmd = _make_cmd(
-            LoginCommand,
-            _params(base_url="https://api.local"),
-        )
+        cmd = _make_cmd(LoginCommand)
         with (
             patch(
                 "dotflow.cli.commands.login.post",
@@ -120,7 +79,7 @@ class TestLoginDeviceFlow:
         gone.status_code = 410
         gone.json.return_value = {"detail": "Device code expired"}
 
-        cmd = _make_cmd(LoginCommand, _params(base_url="https://api.local"))
+        cmd = _make_cmd(LoginCommand)
         with (
             patch(
                 "dotflow.cli.commands.login.post",
@@ -132,10 +91,12 @@ class TestLoginDeviceFlow:
 
         assert not (tmp_home / ".dotflow" / "config.json").exists()
 
-    def test_explicit_base_url_skips_fallback(self, tmp_home):
+    def test_env_var_overrides_default_base_url(self, tmp_home, monkeypatch):
         from requests import ConnectionError as RequestsConnectionError
 
-        cmd = _make_cmd(LoginCommand, _params(base_url="https://only.local"))
+        monkeypatch.setenv("SERVER_BASE_URL", "https://only.local")
+
+        cmd = _make_cmd(LoginCommand)
         with (
             patch(
                 "dotflow.cli.commands.login.post",
@@ -146,6 +107,7 @@ class TestLoginDeviceFlow:
             cmd.setup()
 
         assert mock_post.call_count == 1
+        assert mock_post.call_args.args[0].startswith("https://only.local")
         assert not (tmp_home / ".dotflow" / "config.json").exists()
 
 
@@ -156,11 +118,12 @@ class TestLogout:
             '{"cloud": {"token": "x"}}'
         )
 
-        cmd = _make_cmd(LogoutCommand, _params())
+        cmd = _make_cmd(LogoutCommand)
         cmd.setup()
 
         assert not (tmp_home / ".dotflow" / "config.json").exists()
 
     def test_is_noop_when_no_config(self, tmp_home):
-        cmd = _make_cmd(LogoutCommand, _params())
-        cmd.setup()  # no error expected
+        cmd = _make_cmd(LogoutCommand)
+        cmd.setup()
+        assert not (tmp_home / ".dotflow" / "config.json").exists()

--- a/tests/core/test_dotflow.py
+++ b/tests/core/test_dotflow.py
@@ -70,9 +70,7 @@ class TestDotFlow(unittest.TestCase):
         config = Config(server=server)
         workflow = DotFlow(config=config)
 
-        server.create_workflow.assert_called_once_with(
-            workflow=workflow.workflow_id
-        )
+        server.create_workflow.assert_called_once_with(workflow=workflow)
 
     def test_create_workflow_skipped_when_id_externally_provided(self):
         from dotflow.providers.server_default import ServerDefault
@@ -100,3 +98,25 @@ class TestDotFlow(unittest.TestCase):
         for tid in ids:
             self.assertIsInstance(tid, str)
             self.assertEqual(len(tid), 26)
+
+    def test_default_name_is_hostname(self):
+        import socket
+
+        workflow = DotFlow()
+        self.assertEqual(workflow.name, socket.gethostname())
+
+    def test_explicit_name_overrides_hostname(self):
+        workflow = DotFlow(name="pipeline-xyz")
+        self.assertEqual(workflow.name, "pipeline-xyz")
+
+    def test_start_is_idempotent_for_same_queue(self):
+        first = self.workflow.start()
+        second = self.workflow.start()
+        self.assertIs(first, second)
+
+    def test_start_runs_again_after_task_clear(self):
+        first = self.workflow.start()
+        self.workflow.task.clear()
+        self.workflow.task.add(step=action_step)
+        second = self.workflow.start()
+        self.assertIsNot(first, second)

--- a/tests/core/test_serializer_workflow.py
+++ b/tests/core/test_serializer_workflow.py
@@ -1,0 +1,30 @@
+"""Tests for SerializerWorkflow computed fields."""
+
+from uuid import uuid4
+
+from dotflow.core.serializers.workflow import SerializerWorkflow
+
+
+def test_id_mirrors_workflow_id():
+    wid = uuid4()
+    payload = SerializerWorkflow(
+        workflow_id=wid, workflow_name="host-a"
+    ).model_dump()
+
+    assert payload["workflow_id"] == wid
+    assert payload["id"] == wid
+
+
+def test_name_mirrors_workflow_name():
+    payload = SerializerWorkflow(
+        workflow_id=uuid4(), workflow_name="host-b"
+    ).model_dump()
+
+    assert payload["workflow_name"] == "host-b"
+    assert payload["name"] == "host-b"
+
+
+def test_name_is_none_when_not_set():
+    payload = SerializerWorkflow(workflow_id=uuid4()).model_dump()
+    assert payload["workflow_name"] is None
+    assert payload["name"] is None

--- a/tests/core/test_task.py
+++ b/tests/core/test_task.py
@@ -168,7 +168,11 @@ class TestTaskSetter(unittest.TestCase):
         input_value = "tests.mocks.step_function.action_step"
         expected_value = Action
 
-        task = Task(task_id=0, step=input_value, callback=simple_callback)
+        task = Task(
+            task_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            step=input_value,
+            callback=simple_callback,
+        )
 
         self.assertIsInstance(task.step, expected_value)
 

--- a/tests/providers/test_server_default.py
+++ b/tests/providers/test_server_default.py
@@ -5,6 +5,16 @@ from dotflow.providers.server_default import ServerDefault
 
 
 class TestServerDefault(unittest.TestCase):
+    def setUp(self):
+        self._cfg_patch = patch(
+            "dotflow.core.config_file.load_cloud_config",
+            return_value={},
+        )
+        self._cfg_patch.start()
+
+    def tearDown(self):
+        self._cfg_patch.stop()
+
     @patch.dict("os.environ", {}, clear=True)
     def test_instantiation(self):
         server = ServerDefault()


### PR DESCRIPTION
## Summary

Follow-up to merged PR #271. Tightens the managed/cloud integration pieces around ``dotflow login``.

- ``DotFlow`` gains ``name`` (defaults to ``socket.gethostname()``) and an idempotent ``.start()`` that swallows duplicate calls when the task queue is unchanged.
- ``SerializerWorkflow`` / ``SerializerTask`` now expose ``id``/``name`` as ``@computed_field`` mirrors of the internal ``workflow_id``/``task_id``/``workflow_name`` — API compatibility without duplicating storage.
- ``ServerDefault`` reads from ``~/.dotflow/config.json`` (env wins) and uses the new ``/cli/workflows/*`` endpoints.
- ``dotflow login`` dropped ``--token`` and ``--base-url`` flags (credentials on argv is a security footgun).
- Stray ``breakpoint()`` removed from ``dotflow start --workflow`` path.
- ``hostname()`` helper moved into ``dotflow.utils``.
- New how-to docs for ``dotflow login`` / ``dotflow logout``; ServerDefault page updated.
- Test coverage: ``test_serializer_workflow.py``, idempotent start scenarios, flag-less login assertions.

## Test plan

- [ ] ``poetry run pytest tests/``
- [ ] ``poetry run ruff check`` + ``ruff format --check``
- [ ] Manual: ``dotflow login`` stores config, ``dotflow start --workflow x:main`` runs tasks once